### PR TITLE
Add ability for JS to switch audio/video track

### DIFF
--- a/assets/js/membraneWebRTC.ts
+++ b/assets/js/membraneWebRTC.ts
@@ -317,6 +317,7 @@ export class MembraneWebRTC {
    *  .forEach((track) => webrtc.addTrack(track, localStream));
    *
    * // change camera
+   * const oldDeviceId = localStream.getVideoTracks()[0].getCapabilities().deviceId;
    * let videoDeviceId = "abcd-1234";
    * navigator.mediaDevices.getUserMedia({
    *      video: {
@@ -328,18 +329,19 @@ export class MembraneWebRTC {
    *   })
    *   .then((stream) => {
    *     let videoTrack = stream.getVideoTracks()[0];
-   *     webrtc.replaceTrack(videoTrack);
+   *     webrtc.replaceTrack(oldDeviceId, videoTrack);
    *   })
    *   .catch((error) => {
    *     console.error('Error switching camera', error);
    *   })
    * ```
    */
-  public async replaceTrack(track: MediaStreamTrack): Promise<any> {
+  public async replaceTrack(oldTrackDeviceId: string, newTrack: MediaStreamTrack): Promise<any> {
     const sender = this.connection!.getSenders().find((sender) => {
-      return sender?.track?.kind === track.kind;
+      const capabilities = sender!.track!.getCapabilities();
+      return capabilities.deviceId === oldTrackDeviceId;
     });
-    return sender!.replaceTrack(track);
+    return sender!.replaceTrack(newTrack);
   }
 
   /**

--- a/assets/js/membraneWebRTC.ts
+++ b/assets/js/membraneWebRTC.ts
@@ -317,7 +317,7 @@ export class MembraneWebRTC {
    *  .forEach((track) => webrtc.addTrack(track, localStream));
    *
    * // change camera
-   * const oldDeviceId = localStream.getVideoTracks()[0].getCapabilities().deviceId;
+   * const oldTrackId = localStream.getVideoTracks()[0].id;
    * let videoDeviceId = "abcd-1234";
    * navigator.mediaDevices.getUserMedia({
    *      video: {
@@ -329,17 +329,16 @@ export class MembraneWebRTC {
    *   })
    *   .then((stream) => {
    *     let videoTrack = stream.getVideoTracks()[0];
-   *     webrtc.replaceTrack(oldDeviceId, videoTrack);
+   *     webrtc.replaceTrack(oldTrackId, videoTrack);
    *   })
    *   .catch((error) => {
    *     console.error('Error switching camera', error);
    *   })
    * ```
    */
-  public async replaceTrack(oldTrackDeviceId: string, newTrack: MediaStreamTrack): Promise<any> {
+  public async replaceTrack(oldTrackId: string, newTrack: MediaStreamTrack): Promise<any> {
     const sender = this.connection!.getSenders().find((sender) => {
-      const capabilities = sender!.track!.getCapabilities();
-      return capabilities.deviceId === oldTrackDeviceId;
+      return sender!.track!.id === oldTrackId;
     });
     return sender!.replaceTrack(newTrack);
   }

--- a/assets/js/membraneWebRTC.ts
+++ b/assets/js/membraneWebRTC.ts
@@ -292,6 +292,49 @@ export class MembraneWebRTC {
     this.localTrackIdToMetadata.set(track.id, trackMetadata);
   }
 
+  /**
+   * Replaces a track that is being sent to the SFU server.
+   * At the moment this assumes that only one video and one audio track is being sent.
+   * @param track - Audio or video track.
+   *
+   * @example
+   * ```ts
+   * // setup camera
+   * let localStream: MediaStream = new MediaStream();
+   * try {
+   *   localVideoStream = await navigator.mediaDevices.getUserMedia(
+   *     VIDEO_CONSTRAINTS
+   *   );
+   *   localVideoStream
+   *     .getTracks()
+   *     .forEach((track) => localStream.addTrack(track));
+   * } catch (error) {
+   *   console.error("Couldn't get camera permission:", error);
+   * }
+   *
+   * localStream
+   *  .getTracks()
+   *  .forEach((track) => webrtc.addTrack(track, localStream));
+   *
+   * // change camera
+   * let videoDeviceId = "abcd-1234";
+   * navigator.mediaDevices.getUserMedia({
+   *      video: {
+   *        ...(VIDEO_CONSTRAINTS as {}),
+   *        deviceId: {
+   *          exact: videoDeviceId,
+   *        },
+   *      }
+   *   })
+   *   .then((stream) => {
+   *     let videoTrack = stream.getVideoTracks()[0];
+   *     webrtc.replaceTrack(videoTrack);
+   *   })
+   *   .catch((error) => {
+   *     console.error('Error switching camera', error);
+   *   })
+   * ```
+   */
   public async replaceTrack(track: MediaStreamTrack): Promise<any> {
     const sender = this.connection!.getSenders().find((sender) => {
       return sender?.track?.kind === track.kind;

--- a/assets/js/membraneWebRTC.ts
+++ b/assets/js/membraneWebRTC.ts
@@ -292,6 +292,13 @@ export class MembraneWebRTC {
     this.localTrackIdToMetadata.set(track.id, trackMetadata);
   }
 
+  public async replaceTrack(track: MediaStreamTrack): Promise<any> {
+    const sender = this.connection!.getSenders().find((sender) => {
+      return sender?.track?.kind === track.kind;
+    });
+    return sender!.replaceTrack(track);
+  }
+
   /**
    * Leaves the room. This function should be called when user leaves the room
    * in a clean way e.g. by clicking a dedicated, custom button `disconnect`.


### PR DESCRIPTION
This, like the rest of the JS, assumes only one audio or video track is being streamed up to the SFU. This should close #11.