### PR TITLE
Only run npm install if packages are missing

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -108,7 +108,9 @@ defmodule Membrane.RTC.Engine.MixProject do
     |> case do
       {output, 0} ->
         missing =
-          output |> String.split("\n") |> Enum.filter(&Regex.match?(~r/UNMET DEPENDENCY/, &1))
+          output
+          |> String.split("\n")
+          |> Enum.filter(&Regex.match?(~r/UNMET DEPENDENCY|empty/, &1))
 
         if length(missing) > 0,
           do: false,

--- a/mix.exs
+++ b/mix.exs
@@ -82,14 +82,12 @@ defmodule Membrane.RTC.Engine.MixProject do
   defp compile_ts(_) do
     Mix.shell().info("Installing npm dependencies")
 
-    case packages_installed?() do
-      :ok ->
-        Mix.shell().info("* Already installed")
-
-      :error ->
-        {result, exit_status} = System.cmd("npm", ["ci"], cd: "assets")
-        Mix.shell().info(result)
-        if exit_status != 0, do: raise("Failed to install npm dependecies")
+    if packages_installed?() do
+      Mix.shell().info("* Already installed")
+    else
+      {result, exit_status} = System.cmd("npm", ["ci"], cd: "assets")
+      Mix.shell().info(result)
+      if exit_status != 0, do: raise("Failed to install npm dependecies")
     end
 
     Mix.shell().info("Compiling TS files")
@@ -113,11 +111,11 @@ defmodule Membrane.RTC.Engine.MixProject do
           output |> String.split("\n") |> Enum.filter(&Regex.match?(~r/UNMET DEPENDENCY/, &1))
 
         if length(missing) > 0,
-          do: :error,
-          else: :ok
+          do: false,
+          else: true
 
       {_output, _} ->
-        :error
+        false
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -106,10 +106,11 @@ defmodule Membrane.RTC.Engine.MixProject do
   end
 
   defp packages_installed?() do
-    System.cmd("npm", ["outdated", "--prefix", "assets", "--prefer-offline"])
+    System.cmd("npm", ["ls", "--prefix", "assets", "--prefer-offline"], stderr_to_stdout: true)
     |> case do
       {output, 0} ->
-        missing = output |> String.split("\n") |> Enum.filter(&Regex.match?(~r/MISSING/, &1))
+        missing =
+          output |> String.split("\n") |> Enum.filter(&Regex.match?(~r/UNMET DEPENDENCY/, &1))
 
         if length(missing) > 0,
           do: :error,

--- a/mix.exs
+++ b/mix.exs
@@ -106,7 +106,7 @@ defmodule Membrane.RTC.Engine.MixProject do
   end
 
   defp packages_installed?() do
-    System.cmd("npm", ["outdated", "--prefix", "assets"])
+    System.cmd("npm", ["outdated", "--prefix", "assets", "--prefer-offline"])
     |> case do
       {output, 0} ->
         missing = output |> String.split("\n") |> Enum.filter(&Regex.match?(~r/MISSING/, &1))


### PR DESCRIPTION
This might be helpful when linking a project to a local checkout of the repo for development—dependents won't need to `npm ci` every time they start the server.