### PR TITLE
Add ctx to Track struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ erl_crash.dump
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
 
+### macOS ###
+*.DS_Store
+.AppleDouble
+.LSOverride
+
 # Ignore package tarball (built via "mix hex.build").
 videoroom-*.tar
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -113,7 +113,7 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
         filter_codecs: opts.filter_codecs,
         inbound_tracks: [],
         outbound_tracks: [],
-        extensions: opts.webrtc_extensions || %{},
+        extensions: opts.webrtc_extensions || [],
         integrated_turn_options: opts.integrated_turn_options
       }
 
@@ -125,8 +125,7 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
         ice_name: opts.ice_name,
         outbound_tracks: %{},
         inbound_tracks: %{},
-        extensions: opts.extensions || [],
-        webrtc_extensions: opts.webrtc_extensions || %{},
+        extensions: opts.extensions || %{},
         integrated_turn_options: opts.integrated_turn_options,
         owner: opts.owner
       }
@@ -180,7 +179,7 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
     end
 
     @impl true
-    def handle_notification({:vad, val}, {:endpoint, endpoint_id}, _ctx, state) do
+    def handle_notification({:vad, val}, :endpoint_bin, _ctx, state) do
       send(state.owner, {:vad_notification, val, endpoint_id})
       {:ok, state}
     end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -179,8 +179,8 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
     end
 
     @impl true
-    def handle_notification({:vad, val}, :endpoint_bin, _ctx, state) do
-      send(state.owner, {:vad_notification, val, state.ice_name})
+    def handle_notification({:vad, val}, :endpoint_bin, ctx, state) do
+      send(state.owner, {:vad_notification, val, ctx.name})
       {:ok, state}
     end
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -180,7 +180,7 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
 
     @impl true
     def handle_notification({:vad, val}, :endpoint_bin, _ctx, state) do
-      send(state.owner, {:vad_notification, val, endpoint_id})
+      send(state.owner, {:vad_notification, val, state.ice_name})
       {:ok, state}
     end
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -312,19 +312,6 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
           Map.put(acc, track.id, track)
         end)
 
-    defp to_rtc_track(%WebRTC.Track{} = track, track_id_to_metadata) do
-      %Engine.Track{
-        type: track.type,
-        stream_id: track.stream_id,
-        id: track.id,
-        encoding: track.encoding,
-        format: [:RTP, :raw],
-        fmtp: track.fmtp,
-        active?: track.status != :disabled,
-        metadata: Map.get(track_id_to_metadata, track.id)
-      }
-    end
-
     defp serialize({:signal, {:sdp_answer, answer, mid_to_track_id}}),
       do: %{
         type: "sdpAnswer",
@@ -437,8 +424,26 @@ if Code.ensure_loaded?(Membrane.WebRTC.EndpointBin) do
       end
     end
 
+    defp to_rtc_track(%WebRTC.Track{} = track, track_id_to_metadata) do
+      extension_key = WebRTC.Extension
+
+      %Engine.Track{
+        type: track.type,
+        stream_id: track.stream_id,
+        id: track.id,
+        encoding: track.encoding,
+        format: [:RTP, :raw],
+        fmtp: track.fmtp,
+        active?: track.status != :disabled,
+        metadata: Map.get(track_id_to_metadata, track.id),
+        ctx: %{extension_key => track.extmaps}
+      }
+    end
+
     defp to_webrtc_track(%Engine.Track{} = track) do
       track = if track.active?, do: track, else: Map.put(track, :status, :disabled)
+      extmaps = Map.get(track.ctx, WebRTC.Extension, [])
+      track = Map.put(track, :extmaps, extmaps)
       WebRTC.Track.new(track.type, track.stream_id, to_keyword_list(track))
     end
 

--- a/lib/membrane_rtc_engine/track.ex
+++ b/lib/membrane_rtc_engine/track.ex
@@ -29,7 +29,7 @@ defmodule Membrane.RTC.Engine.Track do
   * `fmtp` - struct describing format specific parameters e.g. for H264 it contains `profile_level_id`
   * `active?` - indicates whether track is still available or not (because peer left a room)
   * `metadata` - any data passed by user to be linked with this track
-  * `ctx` - any data needed to construct protocol-specific Track struct. e.g.: for WebRTC.Track it will be extensions
+  * `ctx` - any data Endpoints need to associate with `#{inspect(__MODULE__)}.t()` for internal usage
   """
   @type t :: %__MODULE__{
           type: :audio | :video,

--- a/lib/membrane_rtc_engine/track.ex
+++ b/lib/membrane_rtc_engine/track.ex
@@ -29,6 +29,7 @@ defmodule Membrane.RTC.Engine.Track do
   * `fmtp` - struct describing format specific parameters e.g. for H264 it contains `profile_level_id`
   * `active?` - indicates whether track is still available or not (because peer left a room)
   * `metadata` - any data passed by user to be linked with this track
+  * `ctx` - any data needed to construct protocol-specific Track struct. e.g.: for WebRTC.Track it will be extensions
   """
   @type t :: %__MODULE__{
           type: :audio | :video,

--- a/lib/membrane_rtc_engine/track.ex
+++ b/lib/membrane_rtc_engine/track.ex
@@ -9,7 +9,7 @@ defmodule Membrane.RTC.Engine.Track do
   alias ExSDP.Attribute.FMTP
 
   @enforce_keys [:type, :stream_id, :id, :fmtp]
-  defstruct @enforce_keys ++ [encoding: nil, format: nil, active?: true, metadata: nil]
+  defstruct @enforce_keys ++ [encoding: nil, format: nil, active?: true, metadata: nil, ctx: %{}]
 
   @type id :: String.t()
   @type encoding :: atom()
@@ -38,7 +38,8 @@ defmodule Membrane.RTC.Engine.Track do
           format: format,
           fmtp: FMTP,
           active?: boolean(),
-          metadata: any()
+          metadata: any(),
+          ctx: map()
         }
 
   @doc """
@@ -54,7 +55,8 @@ defmodule Membrane.RTC.Engine.Track do
           encoding: encoding,
           format: format,
           fmtp: FMTP,
-          metadata: any()
+          metadata: any(),
+          ctx: map()
         ) :: t
   def new(type, stream_id, opts \\ []) do
     id = Keyword.get(opts, :id, Base.encode16(:crypto.strong_rand_bytes(8)))
@@ -66,7 +68,8 @@ defmodule Membrane.RTC.Engine.Track do
       encoding: Keyword.get(opts, :encoding),
       format: Keyword.get(opts, :format),
       fmtp: Keyword.get(opts, :fmtp),
-      metadata: Keyword.get(opts, :metadata)
+      metadata: Keyword.get(opts, :metadata),
+      ctx: Keyword.get(opts, :ctx, %{})
     }
   end
 


### PR DESCRIPTION
Add possibility to transport protocol-specific data inside `RTC.Engine.Track`. For now, used only for WebRTC extensions. It is needed for implementing support for outbound TWCC.