### PR TITLE
Added component_path otel's tag when adding new endpoint

### DIFF
--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -406,6 +406,7 @@ defmodule Membrane.RTC.Engine do
     {{:ok, log_metadata: [rtc: options[:id]]},
      %{
        id: options[:id],
+       component_path: Membrane.ComponentPath.get_formatted() |> IO.inspect,
        trace_context: trace_ctx,
        peers: %{},
        endpoints: %{},
@@ -437,7 +438,7 @@ defmodule Membrane.RTC.Engine do
   end
 
   @impl true
-  @decorate trace("engine.other.add_endpoint", include: [[:state, :id]])
+  @decorate trace("engine.other.add_endpoint", include: [[:state, :component_path], [:state, :id]])
   def handle_other({:add_endpoint, endpoint, opts}, _ctx, state) do
     peer_id = opts[:peer_id]
     endpoint_id = opts[:endpoint_id] || opts[:peer_id]

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -406,7 +406,7 @@ defmodule Membrane.RTC.Engine do
     {{:ok, log_metadata: [rtc: options[:id]]},
      %{
        id: options[:id],
-       component_path: Membrane.ComponentPath.get_formatted() |> IO.inspect,
+       component_path: Membrane.ComponentPath.get_formatted(),
        trace_context: trace_ctx,
        peers: %{},
        endpoints: %{},


### PR DESCRIPTION
This PR introduces one more tag for an opentelemetry span when adding a new endpoint in RTC Engine. The tag name is `state_component_path` and it captures the value of `Membrane.ComponentPath.get_formatted()` so basically pipeline's name. It will allow for tag search done by `membrane_dashboard`.  