### PR TITLE
Fix `add_peer` function and `Membrane.RTC.Engine.Message.t()`

### DIFF
--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -318,13 +318,9 @@ defmodule Membrane.RTC.Engine do
   @doc """
   Adds peer to the RTC Engine
   """
-  @spec add_peer(
-          pid :: pid(),
-          peer_id :: String.t(),
-          data :: any()
-        ) :: :ok
-  def add_peer(pid, peer_id, data \\ %{}) do
-    send(pid, {:add_peer, peer_id, data})
+  @spec add_peer(pid :: pid(), peer :: Peer.t()) :: :ok
+  def add_peer(pid, peer) do
+    send(pid, {:add_peer, peer})
     :ok
   end
 

--- a/lib/membrane_rtc_engine/message.ex
+++ b/lib/membrane_rtc_engine/message.ex
@@ -7,7 +7,7 @@ defmodule Membrane.RTC.Engine.Message do
   """
   alias Membrane.RTC.Engine.Peer
 
-  @type t() :: __MODULE__.MediaEvent.t() | __MODULE__.NewPeer.t()
+  @type t() :: __MODULE__.MediaEvent.t() | __MODULE__.NewPeer.t() | __MODULE__.PeerLeft.t()
 
   defmodule MediaEvent do
     @moduledoc """


### PR DESCRIPTION
closes #68 