### PR TITLE
Only active tracks are in track_id_to_metadata

### DIFF
--- a/lib/membrane_rtc_engine/endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoint.ex
@@ -39,7 +39,11 @@ defmodule Membrane.RTC.Engine.Endpoint do
 
   @spec get_track_id_to_metadata(endpoint :: t()) :: %{Track.id() => any}
   def get_track_id_to_metadata(%__MODULE__{} = endpoint),
-    do: Map.values(endpoint.inbound_tracks) |> Map.new(&{&1.id, &1.metadata})
+    do:
+      endpoint.inbound_tracks
+      |> Map.values()
+      |> Enum.filter(& &1.active?)
+      |> Map.new(&{&1.id, &1.metadata})
 
   def get_track_id_to_metadata(_endpoint), do: %{}
 

--- a/lib/membrane_rtc_engine/endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoint.ex
@@ -37,15 +37,15 @@ defmodule Membrane.RTC.Engine.Endpoint do
     do:
       update_in(endpoint, [:inbound_tracks, track_id, :metadata], fn _old_metadata -> metadata end)
 
-  @spec get_track_id_to_metadata(endpoint :: t()) :: %{Track.id() => any}
-  def get_track_id_to_metadata(%__MODULE__{} = endpoint),
+  @spec get_active_track_metadata(endpoint :: t()) :: %{Track.id() => any}
+  def get_active_track_metadata(%__MODULE__{} = endpoint),
     do:
       endpoint.inbound_tracks
       |> Map.values()
       |> Enum.filter(& &1.active?)
       |> Map.new(&{&1.id, &1.metadata})
 
-  def get_track_id_to_metadata(_endpoint), do: %{}
+  def get_active_track_metadata(_endpoint), do: %{}
 
   @spec update_track_encoding(endpoint :: t(), track_id :: Track.id(), encoding :: atom) :: t()
   def update_track_encoding(endpoint, track_id, value),

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -869,7 +869,8 @@ defmodule Membrane.RTC.Engine do
 
   defp setup_endpoint(endpoint_entry, opts, state) do
     inbound_tracks = []
-    outbound_tracks = get_outbound_tracks(state.endpoints)
+
+    outbound_tracks = state.endpoints |> get_outbound_tracks() |> Enum.filter(& &1.active?)
 
     endpoint_id = opts[:endpoint_id] || opts[:peer_id]
     endpoint = Endpoint.new(endpoint_id, inbound_tracks)

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -743,7 +743,7 @@ defmodule Membrane.RTC.Engine do
       )
 
     endpoint = get_in(state, [:endpoints, endpoint_id])
-    track_id_to_track_metadata = Endpoint.get_track_id_to_metadata(endpoint)
+    track_id_to_track_metadata = Endpoint.get_active_track_metadata(endpoint)
 
     MediaEvent.create_tracks_added_event(endpoint_id, track_id_to_track_metadata)
     |> then(&%Message.MediaEvent{rtc_engine: self(), to: :broadcast, data: &1})

--- a/lib/membrane_rtc_engine/media_event.ex
+++ b/lib/membrane_rtc_engine/media_event.ex
@@ -10,7 +10,7 @@ defmodule Membrane.RTC.Engine.MediaEvent do
   def create_peer_accepted_event(peer_id, peers, endpoints) do
     peers =
       Enum.map(peers, fn {id, peer} ->
-        track_id_to_track_metadata = Endpoint.get_track_id_to_metadata(endpoints[id])
+        track_id_to_track_metadata = Endpoint.get_active_track_metadata(endpoints[id])
         %{id: id, metadata: peer.metadata, trackIdToMetadata: track_id_to_track_metadata}
       end)
 


### PR DESCRIPTION
related to https://github.com/membraneframework/membrane_webrtc_plugin/pull/70
In track_id_to_metadata should be only active tracks.