### PR TITLE
Enhance API for configuring simulcast. Fix switching between available simulcast encodings

### DIFF
--- a/assets/js/const.ts
+++ b/assets/js/const.ts
@@ -1,6 +1,6 @@
 // const TEMPORAL_LAYERS_COUNT = 2;
 
-export const simulcastConfig: RTCRtpTransceiverInit = {
+export const simulcastTransceiverConfig: RTCRtpTransceiverInit = {
   direction: "sendonly",
   // keep this array from low resolution to high resolution
   // in other case lower resolution encoding can get
@@ -8,19 +8,19 @@ export const simulcastConfig: RTCRtpTransceiverInit = {
   sendEncodings: [
     {
       rid: "l",
-      active: true,
+      active: false,
       // maxBitrate: 4_000_000,
       scaleResolutionDownBy: 4.0,
       //   scalabilityMode: "L1T" + TEMPORAL_LAYERS_COUNT,
     },
     {
       rid: "m",
-      active: true,
+      active: false,
       scaleResolutionDownBy: 2.0,
     },
     {
       rid: "h",
-      active: true,
+      active: false,
       // maxBitrate: 4_000_000,
       // scalabilityMode: "L1T" + TEMPORAL_LAYERS_COUNT,
     },

--- a/assets/js/membraneWebRTC.ts
+++ b/assets/js/membraneWebRTC.ts
@@ -89,8 +89,14 @@ export interface TrackContext {
 
 /**
  * Type describing possible track encodings.
- * At the moment, if track was added as a simulcast one ({@link addTrack})
- * it will be transmitted to the server in three versions - low, medium and high.
+ * `"h"` - original encoding
+ * `"m"` - original encoding scaled down by 2
+ * `"l"` - original encoding scaled down by 4
+ *
+ * Notice that to make all encodings work, the initial
+ * resolution has to be at least 1280x720.
+ * In other case, browser might not be able to scale
+ * some encodings down.
  */
 export type TrackEncoding = "l" | "m" | "h";
 
@@ -308,7 +314,7 @@ export class MembraneWebRTC {
               stream: null,
               track: null,
               trackId,
-              simulcastConfig: { enabled: false, encodings: [], active_encodings: [] },
+              simulcastConfig: { enabled: false, active_encodings: [] },
               metadata,
               peer,
               maxBandwidth: 0,

--- a/guides/simulcast.md
+++ b/guides/simulcast.md
@@ -4,21 +4,19 @@ Simulcast is a technique where a client sends multiple encodings of the same vid
 
 * receiver awailable bandwidth
 * receiver preferences (e.g. explicit request to receive video in HD resolution instead of FHD)
-* UI layaout (e.g. videos being displayed in smaller video tiles will be sent in lower resolution)
+* UI layaout (e.g. videos being displayed in smaller video tiles will be sent in a lower resolution)
 
-At the moment, Membrane supports only receiver preferences i.e. receiver can chose which encoding it is willing to receive. Additionaly, sender can turn off/on specific encoding. Membrane RTC Engine will detect changes and switch to another available encoding.Simulcast is a technique where client sends multiple encodings (different resolutions) of the same
-video to a server and the server forwards proper encoding to each other client basing on 
-client preferences, network bandwidth or UI layaout.
+At the moment, Membrane supports only receiver preferences i.e. receiver can chose which encoding it is willing to receive. Additionaly, sender can turn off/on specific encoding. Membrane RTC Engine will detect changes and switch to another available encoding.
 
 ## Turning simulcast on/off
 
-On the client side simulcast can be enabled while adding new track e.g.:
+On the client side simulcast can be enabled while adding a new track e.g.:
 
 ```ts
     // create MembraneWebRTC class instance
     // ...
     // add simulcasted track
-    let trackId = webrtc.addTrack(track, stream, {}, true);
+    let trackId = webrtc.addTrack(track, stream, {}, {enabled: true, active_encodings: ["l", "m", "h"]});
 ```
 
 This will add a new track that will be sent in three versions:
@@ -26,7 +24,8 @@ This will add a new track that will be sent in three versions:
 * original scaled down by 2 (identified as `m`)
 * original scaled down by 4 (identified as `l`)
 
-Those settings are not configurable at the moment.
+You can turn off some of the encodings by excluding them from `active_encodings` list.
+Encodings that are turned off might still be enabled using `enableTrackEncoding` function.
 
 > #### Minimal required resolution {: .warning}
 >
@@ -36,9 +35,24 @@ Those settings are not configurable at the moment.
 > passed to [`getUserMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia) 
 > or [`getDisplayMedia`](https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getDisplayMedia).
 
-On the server side, simulcast can be disabled while adding new WebRTC Endpoint by setting its `simulcast?` 
-option to `false`.
-This will result in rejecting all incoming simulcast tracks i.e. client will not send them.
+On the server side, simulcast can be configured while adding new WebRTC Endpoint by setting its `simulcast_config` option.
+
+For example
+
+```elixir
+%WebRTC{
+  rtc_engine: rtc_engine,
+  # ...
+  simulcast_config: %SimulcastConfig{
+    enabled: true,
+    default_encoding: fn %Track{simulcast_encodings: _simulcast_encodings} -> "m" end
+  }
+}
+```
+
+Here we turn simulcast on and choose medium encoding for each track to be forwarded to the client.
+
+On the other hand, setting `enabled` to `false` will result in rejecting all incoming simulcast tracks i.e. client will not send them to the server.
 
 ## Disabling and enabling specific track encoding
 
@@ -58,7 +72,7 @@ Disabled encoding can be turned on again using `enableTrackEncoding` function.
 Membrane RTC Engine tracks encoding activity. 
 Therefore, when some encoding is turned off, RTC Engine will detect this and switch to 
 the highest awailable encoding.
-If turned off encoding returns, RTC Engine will switch back to it.
+When disabled encoding becomes active again, RTC Engine will switch back to it.
 
 ## Selecting encoding to receive
 

--- a/lib/membrane_rtc_engine/endpoints/hls_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/hls_endpoint.ex
@@ -80,14 +80,13 @@ if Enum.all?(
 
     @impl true
     def handle_other({:new_tracks, tracks}, ctx, state) do
-      new_tracks = Map.new(tracks, &{&1.id, &1})
-
       {:endpoint, endpoint_id} = ctx.name
+      tracks = Enum.filter(tracks, fn track -> :raw in track.format end)
 
       Enum.each(tracks, fn track ->
-        case Engine.subscribe(state.rtc_engine, endpoint_id, track.id, :RTP) do
+        case Engine.subscribe(state.rtc_engine, endpoint_id, track.id, :raw) do
           :ok ->
-            {:ok, Map.update!(state, :tracks, &Map.merge(&1, new_tracks))}
+            {:ok, Map.update!(state, :tracks, &Map.put(&1, track.id, track))}
 
           {:error, reason} ->
             raise "Couldn't subscribe for track: #{inspect(track.id)}. Reason: #{inspect(reason)}"

--- a/lib/membrane_rtc_engine/endpoints/hls_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/hls_endpoint.ex
@@ -86,7 +86,7 @@ if Enum.all?(
       Enum.each(tracks, fn track ->
         case Engine.subscribe(state.rtc_engine, endpoint_id, track.id, :raw) do
           :ok ->
-            {:ok, Map.update!(state, :tracks, &Map.put(&1, track.id, track))}
+            {:ok, put_in(state, [:tracks, track.id], track)}
 
           {:error, reason} ->
             raise "Couldn't subscribe for track: #{inspect(track.id)}. Reason: #{inspect(reason)}"

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_config.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_config.ex
@@ -16,7 +16,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastConfig do
   """
   @type t() :: %__MODULE__{
           enabled: boolean(),
-          default_encoding: (Track.t() -> String.t())
+          default_encoding: (Track.t() -> String.t() | nil)
         }
   defstruct enabled: false,
             default_encoding: &__MODULE__.default_encoding/1
@@ -26,5 +26,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastConfig do
 
   Returns nil, which will result in choosing the highest possible encoding.
   """
+  @spec default_encoding(Track.t()) :: nil
   def default_encoding(_track), do: nil
 end

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_config.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_config.ex
@@ -1,0 +1,24 @@
+defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastConfig do
+  @moduledoc """
+  Module representing simulcast configuration for WebRTC endpoint.
+  """
+
+  alias Membrane.RTC.Engine.Track
+
+  @typedoc """
+  * `enabled` - whether to accept simulcast tracks or not.
+  Setting this to false will result in rejecting all incoming
+  simulcast tracks i.e. client will not send them.
+  * `default_encoding` - function used to determine initial encoding
+  this endpoint is willing to receive for given track.
+  It is called for each track this endpoint subscribes for.
+  """
+  @type t() :: %__MODULE__{
+          enabled: boolean(),
+          default_encoding: (Track.t() -> String.t())
+        }
+  defstruct [
+    :default_encoding,
+    enabled: false
+  ]
+end

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_config.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_config.ex
@@ -12,13 +12,19 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastConfig do
   * `default_encoding` - function used to determine initial encoding
   this endpoint is willing to receive for given track.
   It is called for each track this endpoint subscribes for.
+  If not provided, the highest possible encoding will be used.
   """
   @type t() :: %__MODULE__{
           enabled: boolean(),
           default_encoding: (Track.t() -> String.t())
         }
-  defstruct [
-    :default_encoding,
-    enabled: false
-  ]
+  defstruct enabled: false,
+            default_encoding: &__MODULE__.default_encoding/1
+
+  @doc """
+  Default implementation of `default_encoding` function in `t:t/0`.
+
+  Returns nil, which will result in choosing the highest possible encoding.
+  """
+  def default_encoding(_track), do: nil
 end

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
@@ -30,7 +30,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
         spec: String.t() | nil,
         default: nil,
         description: """
-        TODO
+        Initial encoding that should be sent via this pad.
+        `nil` means that the best possible encoding should be used.
         """
       ]
     ]

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
@@ -24,7 +24,16 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
   def_output_pad :output,
     availability: :on_request,
     mode: :push,
-    caps: Membrane.RTP
+    caps: Membrane.RTP,
+    options: [
+      default_simulcast_encoding: [
+        spec: String.t() | nil,
+        default: nil,
+        description: """
+        TODO
+        """
+      ]
+    ]
 
   @typedoc """
   Notifies that encoding for endpoint with id `endpoint_id` was switched to encoding `encoding`.
@@ -58,9 +67,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
   end
 
   @impl true
-  def handle_pad_added(Pad.ref(:output, {:endpoint, endpoint_id}), _context, state) do
+  def handle_pad_added(Pad.ref(:output, {:endpoint, endpoint_id}), context, state) do
     forwarder =
-      Forwarder.new(state.track.encoding, state.track.clock_rate, state.track.simulcast_encodings)
+      Forwarder.new(
+        state.track.encoding,
+        state.track.clock_rate,
+        state.track.simulcast_encodings,
+        context.options[:default_simulcast_encoding]
+      )
 
     forwarder =
       Enum.reduce(state.inactive_encodings, forwarder, fn encoding, forwarder ->

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
@@ -57,8 +57,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
          "l" => EncodingTracker.new("l"),
          "m" => EncodingTracker.new("m"),
          "h" => EncodingTracker.new("h")
-       },
-       update?: false
+       }
      }}
   end
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/simulcast_tee.ex
@@ -9,15 +9,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
 
   @supported_codecs [:H264, :VP8]
 
-  def_options codec: [
-                type: :atom,
-                spec: [:H264 | :VP8],
-                description: "Codec of track #{inspect(__MODULE__)} will forward."
-              ],
-              clock_rate: [
-                type: :integer,
-                spec: Membrane.RTP.clock_rate_t(),
-                description: "Clock rate of track #{inspect(__MODULE__)} will forward."
+  def_options track: [
+                type: :struct,
+                spec: Membrane.RTC.Engine.Track.t(),
+                description: "Track this tee is going to forward to other endpoints"
               ]
 
   def_input_pad :input,
@@ -39,25 +34,21 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
 
   @impl true
   def handle_init(opts) do
-    codec = opts.codec
-
-    if codec not in @supported_codecs do
+    if opts.track.encoding not in @supported_codecs do
       raise("""
-      #{inspect(__MODULE__)} does not support codec #{inspect(codec)}.
+      #{inspect(__MODULE__)} does not support codec #{inspect(opts.track.encoding)}.
       Supported codecs: #{inspect(@supported_codecs)}
       """)
     end
 
+    trackers = Map.new(opts.track.simulcast_encodings, &{&1, EncodingTracker.new(&1)})
+
     {:ok,
      %{
-       codec: codec,
-       clock_rate: opts.clock_rate,
+       track: opts.track,
        forwarders: %{},
-       trackers: %{
-         "l" => EncodingTracker.new("l"),
-         "m" => EncodingTracker.new("m"),
-         "h" => EncodingTracker.new("h")
-       }
+       trackers: trackers,
+       inactive_encodings: []
      }}
   end
 
@@ -68,9 +59,15 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
 
   @impl true
   def handle_pad_added(Pad.ref(:output, {:endpoint, endpoint_id}), _context, state) do
-    state =
-      put_in(state, [:forwarders, endpoint_id], Forwarder.new(state.codec, state.clock_rate))
+    forwarder =
+      Forwarder.new(state.track.encoding, state.track.clock_rate, state.track.simulcast_encodings)
 
+    forwarder =
+      Enum.reduce(state.inactive_encodings, forwarder, fn encoding, forwarder ->
+        Forwarder.encoding_inactive(forwarder, encoding)
+      end)
+
+    state = put_in(state, [:forwarders, endpoint_id], forwarder)
     {:ok, state}
   end
 
@@ -127,18 +124,25 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastTee do
       {:ok, tracker} ->
         put_in(state, [:trackers, rid], tracker)
 
-      {:status_changed, tracker, new_status} ->
-        func =
-          if new_status == :inactive,
-            do: &Forwarder.encoding_inactive(&1, rid),
-            else: &Forwarder.encoding_active(&1, rid)
-
+      {:status_changed, tracker, :active} ->
         state =
           Enum.reduce(state.forwarders, state, fn {endpoint_id, forwarder}, state ->
-            put_in(state, [:forwarders, endpoint_id], func.(forwarder))
+            put_in(state, [:forwarders, endpoint_id], Forwarder.encoding_active(forwarder, rid))
           end)
 
-        put_in(state, [:trackers, rid], tracker)
+        state
+        |> update_in([:inactive_encodings], &List.delete(&1, rid))
+        |> put_in([:trackers, rid], tracker)
+
+      {:status_changed, tracker, :inactive} ->
+        state =
+          Enum.reduce(state.forwarders, state, fn {endpoint_id, forwarder}, state ->
+            put_in(state, [:forwarders, endpoint_id], Forwarder.encoding_inactive(forwarder, rid))
+          end)
+
+        state
+        |> update_in([:inactive_encodings], &[rid | &1])
+        |> put_in([:trackers, rid], tracker)
     end
   end
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -13,6 +13,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   alias Membrane.RTC.Engine
   alias ExSDP.Attribute.FMTP
   alias ExSDP.Attribute.RTPMapping
+  alias Membrane.RTC.Engine.Endpoint.WebRTC.SimulcastConfig
 
   require Membrane.Logger
 
@@ -147,15 +148,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
                 For more information refer to RFC 5104 section 4.3.1.
                 """
               ],
-              simulcast?: [
-                spec: boolean(),
-                default: true,
-                description: """
-                Whether to accept simulcast tracks or not.
-
-                Setting this to false will result in rejecting all incoming
-                simulcast tracks i.e. client will not send them.
-                """
+              simulcast_config: [
+                spec: SimulcastConfig.t(),
+                default: %SimulcastConfig{},
+                description: "Simulcast configuration"
               ]
 
   def_input_pad :input,
@@ -185,7 +181,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       trace_metadata: [name: opts.ice_name],
       rtcp_receiver_report_interval: opts.rtcp_receiver_report_interval,
       rtcp_sender_report_interval: opts.rtcp_sender_report_interval,
-      simulcast?: opts.simulcast?
+      simulcast?: opts.simulcast_config.enabled
     }
 
     spec = %ParentSpec{
@@ -203,7 +199,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       integrated_turn_domain: opts.integrated_turn_domain,
       owner: opts.owner,
       video_tracks_limit: opts.video_tracks_limit,
-      rtcp_fir_interval: opts.rtcp_fir_interval
+      rtcp_fir_interval: opts.rtcp_fir_interval,
+      simulcast_config: opts.simulcast_config
     }
 
     {{:ok, spec: spec, log_metadata: opts.log_metadata}, state}
@@ -245,9 +242,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
     {:endpoint, endpoint_id} = ctx.name
 
-    opts = [default_simulcast_encoding: "m"]
-
     Enum.each(new_outbound_tracks, fn track ->
+      opts = [default_simulcast_encoding: state.simulcast_config.default_encoding.(track)]
       case Engine.subscribe(state.rtc_engine, endpoint_id, track.id, :RTP, opts) do
         :ok ->
           :ok

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -244,6 +244,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
     Enum.each(new_outbound_tracks, fn track ->
       opts = [default_simulcast_encoding: state.simulcast_config.default_encoding.(track)]
+
       case Engine.subscribe(state.rtc_engine, endpoint_id, track.id, :RTP, opts) do
         :ok ->
           :ok

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -959,15 +959,15 @@ defmodule Membrane.RTC.Engine do
       end
     ]
 
-    {pending_subscriptions, rest} =
+    {pending_track_subscriptions, pending_rest_subscriptions} =
       Enum.split_with(state.pending_subscriptions, fn s -> s.track_id == track.id end)
 
     {links, state} =
-      Enum.flat_map_reduce(pending_subscriptions, state, fn subscription, state ->
+      Enum.flat_map_reduce(pending_track_subscriptions, state, fn subscription, state ->
         fulfill_subscription(subscription, ctx, state)
       end)
 
-    state = %{state | pending_subscriptions: rest}
+    state = %{state | pending_subscriptions: pending_rest_subscriptions}
     {endpoint_to_tee_links ++ links, state}
   end
 

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -1178,7 +1178,7 @@ defmodule Membrane.RTC.Engine do
       {_subscriptions, state} = pop_in(state, [:subscriptions, endpoint_id])
 
       state =
-        update_in(state, [:pending_subscriptions, endpoint_id], fn subscriptions ->
+        update_in(state, [:pending_subscriptions], fn subscriptions ->
           Enum.filter(subscriptions, fn s -> s.endpoint_id != endpoint_id end)
         end)
 

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -964,7 +964,7 @@ defmodule Membrane.RTC.Engine do
     tee =
       cond do
         rid != nil ->
-          %SimulcastTee{codec: track.encoding, clock_rate: track.clock_rate}
+          %SimulcastTee{track: track}
 
         state.display_manager != nil ->
           %Engine.Tee{ets_name: state.id, track_id: track_id, type: track.type}

--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -839,7 +839,7 @@ defmodule Membrane.RTC.Engine do
 
     state = put_in(state, [:filters, track_id], depayloading_filter)
     track = state.endpoints |> Map.fetch!(endpoint_id) |> Endpoint.get_track_by_id(track_id)
-    {tee_links, state} = create_tee_and_link(track_id, rid, track, endpoint_id, ctx, state)
+    {tee_links, state} = create_and_link_tee(track_id, rid, track, endpoint_id, ctx, state)
 
     # check if there are subscriptions for this track and fulfill them
     {pending_track_subscriptions, pending_rest_subscriptions} =
@@ -937,7 +937,7 @@ defmodule Membrane.RTC.Engine do
     {:ok, state}
   end
 
-  defp create_tee_and_link(track_id, rid, track, endpoint_id, ctx, state) do
+  defp create_and_link_tee(track_id, rid, track, endpoint_id, ctx, state) do
     tee =
       cond do
         rid != nil ->
@@ -1025,9 +1025,9 @@ defmodule Membrane.RTC.Engine do
     do_fulfill_subscription(subscription, :tee, state)
   end
 
-  defp do_fulfill_subscription(s, tee_kind, state) do
-    links = prepare_track_to_endpoint_links(s, tee_kind, state)
-    subscription = %Subscription{s | status: :active}
+  defp do_fulfill_subscription(subscription, tee_kind, state) do
+    links = prepare_track_to_endpoint_links(subscription, tee_kind, state)
+    subscription = %Subscription{subscription | status: :active}
     endpoint_id = subscription.endpoint_id
     track_id = subscription.track_id
     state = put_in(state, [:subscriptions, endpoint_id, track_id], subscription)

--- a/lib/membrane_rtc_engine/subscription.ex
+++ b/lib/membrane_rtc_engine/subscription.ex
@@ -1,0 +1,32 @@
+defmodule Membrane.RTC.Engine.Subscription do
+  @moduledoc false
+  # Module representing subscription for track
+  alias Membrane.RTC.Engine.{Endpoint, Track}
+
+  @typedoc """
+  Subscription options.
+
+  * `default_simulcast_encoding` - initial encoding that
+  endpoint making subscription wants to receive
+  """
+  @type opts_t :: [default_simulcast_encoding: String.t()]
+
+  @typedoc """
+  * `endpoint_id` - id of endpoint making subscription for track
+  * `track_id` - id of track endpoint subscribes for
+  * `format` - format of track endpoint subscribes for
+  * `status` - status of subscription. Subscription is `active` when
+  given track is linked to given endpoint and `pending` otherwise
+  * `opts` - additional options
+  """
+  @type t() :: %___MODULE__{
+          endpoint_id: Endpoint.id(),
+          track_id: Track.id(),
+          format: Track.format(),
+          status: :created | :pending | :active,
+          opts: opts_t()
+        }
+
+  @enforce_keys [:endpoint_id, :track_id, :format, :status, :opts]
+  defstruct @enforce_keys
+end

--- a/lib/membrane_rtc_engine/subscription.ex
+++ b/lib/membrane_rtc_engine/subscription.ex
@@ -1,32 +1,26 @@
 defmodule Membrane.RTC.Engine.Subscription do
   @moduledoc false
   # Module representing subscription for track
+  alias Membrane.RTC.Engine
   alias Membrane.RTC.Engine.{Endpoint, Track}
 
   @typedoc """
-  Subscription options.
-
-  * `default_simulcast_encoding` - initial encoding that
-  endpoint making subscription wants to receive
-  """
-  @type opts_t :: [default_simulcast_encoding: String.t()]
-
-  @typedoc """
-  * `endpoint_id` - id of endpoint making subscription for track
+  * `endpoint_id` - id of endpoint making subscription
   * `track_id` - id of track endpoint subscribes for
   * `format` - format of track endpoint subscribes for
-  * `status` - status of subscription. Subscription is `active` when
-  given track is linked to given endpoint and `pending` otherwise
+  * `status` - status of subscription. Subscription is
+  `active` when track some endpoint subscribed for is linked
+  to this endpoint and `pending` otherwise
   * `opts` - additional options
   """
-  @type t() :: %___MODULE__{
+  @type t() :: %__MODULE__{
           endpoint_id: Endpoint.id(),
           track_id: Track.id(),
           format: Track.format(),
-          status: :created | :pending | :active,
-          opts: opts_t()
+          status: :pending | :active,
+          opts: Engine.subscription_opts_t()
         }
 
-  @enforce_keys [:endpoint_id, :track_id, :format, :status, :opts]
-  defstruct @enforce_keys
+  @enforce_keys [:endpoint_id, :track_id, :format]
+  defstruct @enforce_keys ++ [status: :pending, opts: []]
 end

--- a/test/membrane_rtc_engine/webrtc/forwarder_test.exs
+++ b/test/membrane_rtc_engine/webrtc/forwarder_test.exs
@@ -4,14 +4,22 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ForwarderTest do
   alias Membrane.RTC.Engine.Endpoint.WebRTC.Forwarder
 
   test "Forwarder switches back to encoding being used before it became inactive" do
-    forwarder = Forwarder.new(:VP8, 90_000)
+    forwarder = Forwarder.new(:VP8, 90_000, ["l", "m", "h"])
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: nil,
+             old_encoding: nil,
+             active_encodings: ["l", "m", "h"]
+           } = forwarder
+
     forwarder = Forwarder.encoding_inactive(forwarder, "h")
 
     assert %Forwarder{
              selected_encoding: "h",
              queued_encoding: "m",
              old_encoding: "h",
-             active_encodings: ["m", "l"]
+             active_encodings: ["l", "m"]
            } = forwarder
 
     forwarder = Forwarder.encoding_active(forwarder, "h")
@@ -20,7 +28,65 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ForwarderTest do
              selected_encoding: "h",
              queued_encoding: nil,
              old_encoding: nil,
-             active_encodings: ["m", "l", "h"]
+             active_encodings: ["l", "m", "h"]
+           } = forwarder
+  end
+
+  test "Forwarder doesn't switch to a new encoding when not currently used encoding is marked as inactive" do
+    forwarder = Forwarder.new(:VP8, 90_000, ["l", "m", "h"])
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: nil,
+             old_encoding: nil,
+             active_encodings: ["l", "m", "h"]
+           } = forwarder
+
+    forwarder = Forwarder.encoding_inactive(forwarder, "m")
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: nil,
+             old_encoding: nil,
+             active_encodings: ["l", "h"]
+           } = forwarder
+  end
+
+  test "Forwarder switches to a new encoding when it is better than currently used encoding and while waiting for the actual encoding" do
+    forwarder = Forwarder.new(:VP8, 90_000, ["l", "m", "h"])
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: nil,
+             old_encoding: nil,
+             active_encodings: ["l", "m", "h"]
+           } = forwarder
+
+    forwarder = Forwarder.encoding_inactive(forwarder, "m")
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: nil,
+             old_encoding: nil,
+             active_encodings: ["l", "h"]
+           } = forwarder
+
+    forwarder = Forwarder.encoding_inactive(forwarder, "h")
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: "l",
+             old_encoding: "h",
+             active_encodings: ["l"]
+           } = forwarder
+
+    forwarder = Forwarder.encoding_active(forwarder, "m")
+
+    assert %Forwarder{
+             selected_encoding: "h",
+             queued_encoding: "m",
+             old_encoding: "h",
+             active_encodings: ["l", "m"]
            } = forwarder
   end
 end


### PR DESCRIPTION
* enhance API for configuring simulcast both on the client and server sides. Now user can choose, which simulcast encodings should be by default enabled on the client side i.e. sent to the server. Besides this, user can choose which encoding should be by default passed to the client from the server. This can be configured per track.
* fix switching between encodings when one of them becomes active or inactive
* refactor a little internal linking mechanism
* now endpoint can subscribe only for one track i.e. it cannot pass list of tracks it subscribes for