### PR TITLE
Fix RC when subscribing to a track

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/hls_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/hls_endpoint.ex
@@ -88,6 +88,12 @@ if Enum.all?(
           :ok ->
             {:ok, put_in(state, [:tracks, track.id], track)}
 
+          {:error, :invalid_track_id} ->
+            Membrane.Logger.debug("""
+            Couldn't subscribe to track: #{inspect(track.id)}. No such track.
+            It had to be removed just after publishing it. Ignoring.
+            """)
+
           {:error, reason} ->
             raise "Couldn't subscribe for track: #{inspect(track.id)}. Reason: #{inspect(reason)}"
         end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -231,8 +231,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
         :ok ->
           :ok
 
+        {:error, :invalid_track_id} ->
+          Membrane.Logger.debug("""
+          Couldn't subscribe to track: #{inspect(track.id)}. No such track.
+          It had to be removed before we restarted ICE. Ignoring.
+          """)
+
         {:error, reason} ->
-          raise "Couldn't subscribe for track: #{inspect(track.id)}. Reason: #{inspect(reason)}"
+          raise "Couldn't subscribe to track: #{inspect(track.id)}. Reason: #{inspect(reason)}"
       end
     end)
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -234,7 +234,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
         {:error, :invalid_track_id} ->
           Membrane.Logger.debug("""
           Couldn't subscribe to track: #{inspect(track.id)}. No such track.
-          It had to be removed before we restarted ICE. Ignoring.
+          It was probably removed before we restarted ICE. Ignoring.
           """)
 
         {:error, reason} ->


### PR DESCRIPTION
When subscribing to a track we might fail because track we are trying to subscribe to has been deleted just before doing the subscription and we haven't received this information yet. This PR fixes that RC by ignoring `{:error, :invalid_track_id}` returned from `Engine.subscribe`.

The other solution would be to distinct between `:invalid_track_id` and `:track_already_removed` errors. To achieve this we had to introduce buffer for already removed tracks with some arbitrary capacity.