### PR TITLE
Fix raw format links

### DIFF
--- a/lib/membrane_rtc_engine/engine.ex
+++ b/lib/membrane_rtc_engine/engine.ex
@@ -1047,7 +1047,7 @@ defmodule Membrane.RTC.Engine do
       if Map.has_key?(ctx.children, {:raw_format_tee, subscription.track_id}) do
         []
       else
-        prepare_raw_format_links(subscription.track_id, state)
+        prepare_raw_format_links(subscription.track_id, subscription.endpoint_id, state)
       end
 
     {links, state} = do_fulfill_subscription(subscription, :raw_format_tee, state)
@@ -1068,11 +1068,14 @@ defmodule Membrane.RTC.Engine do
     {links, state}
   end
 
-  defp prepare_raw_format_links(track_id, state) do
+  defp prepare_raw_format_links(track_id, endpoint_id, state) do
+    track = get_track(track_id, state.endpoints)
+
     [
       link({:tee, track_id})
+      |> via_out(Pad.ref(:output, {:endpoint, endpoint_id}))
       |> to({:raw_format_filter, track_id}, get_in(state, [:filters, track_id]))
-      |> to({:raw_format_tee, track_id}, Engine.PushOutputTee)
+      |> to({:raw_format_tee, track_id}, %Engine.PushOutputTee{codec: track.encoding})
     ]
   end
 


### PR DESCRIPTION
- This happens when using both a WebRTC and a custom Endpoint in RTC Engine
- Given custom Endpoint subscribes to raw tracks, tees are set up
- Change 1: The upstream tee may require pad naming to conform to {:endpoint, id}
- Change 2: Engine.PushOutputTee requires codec

Reproduction:
1. Update the WebRTC to HLS demo with latest versions of everything published by the Membrane team
2. Note that it doesn’t work
3. Note that changes within this fork are needed for the custom endpoint to work