### PR TITLE
Fix subscribing to tracks in HLS Endpoint. Fix handling multiple raw subscriptions in Engine.

### DIFF
--- a/test/membrane_rtc_engine/media_event_test.exs
+++ b/test/membrane_rtc_engine/media_event_test.exs
@@ -22,7 +22,7 @@ defmodule Membrane.RTC.Engine.MediaEventTest do
         }
       }
 
-      assert {:ok, expected_media_event} == MediaEvent.deserialize(raw_media_event)
+      assert {:ok, expected_media_event} == MediaEvent.decode(raw_media_event)
     end
 
     test "returns error when event misses key" do
@@ -36,7 +36,7 @@ defmodule Membrane.RTC.Engine.MediaEventTest do
         }
         |> Jason.encode!()
 
-      assert {:error, :invalid_media_event} == MediaEvent.deserialize(raw_media_event)
+      assert {:error, :invalid_media_event} == MediaEvent.decode(raw_media_event)
     end
   end
 end


### PR DESCRIPTION
Reproduction:
1. Add HLS endpoint which subscribes to raw data.
2. Add another custom endpoint which also subscribes to raw data.
3. Observe that it does not work because of incorrect routing and assignment of tees.
4. Use changes in this fork.
5. Observe that both custom endpoints now work and receive the correct streams.

Changes:
1. Fixed HLS endpoint which did not start correctly.
2. Fixed RTC engine so it would hang raw format filters/tees under the track’s tee using pad `{:endpoint, :shared}`, which correctly works with the Simulcast tee.
3. Added general formatting fixes.