### PR TITLE
Fix display manager

### DIFF
--- a/lib/membrane_rtc_engine/display_manager/display_manager.ex
+++ b/lib/membrane_rtc_engine/display_manager/display_manager.ex
@@ -115,7 +115,11 @@ defmodule Membrane.RTC.Engine.DisplayManager do
         &EndpointManager.add_tracks(&1, tracks, :outbound_tracks)
       )
 
-    {:noreply, %{state | endpoint_managers: endpoints}}
+    state = %{state | endpoint_managers: endpoints}
+
+    state = maybe_calculate_priority(state, [{:subscribe_on_tracks, endpoint_name} | state.vads])
+
+    {:noreply, state}
   end
 
   @impl true

--- a/lib/membrane_rtc_engine/display_manager/display_manager.ex
+++ b/lib/membrane_rtc_engine/display_manager/display_manager.ex
@@ -238,8 +238,6 @@ defmodule Membrane.RTC.Engine.DisplayManager do
       |> Enum.sort_by(fn {_endpoint_name, time} -> time end, &sorting_vads/2)
       |> Enum.map(fn {endpoint_name, _time} -> endpoint_name end)
 
-    IO.inspect(ordered_endpoint_names, label: :ordered_endpoint_names)
-
     ordered_tracks =
       Enum.flat_map(ordered_endpoint_names, fn endpoint_name ->
         endpoint_managers |> Map.get(endpoint_name) |> EndpointManager.get_inbound_video_tracks()

--- a/lib/membrane_rtc_engine/display_manager/display_manager.ex
+++ b/lib/membrane_rtc_engine/display_manager/display_manager.ex
@@ -25,7 +25,11 @@ defmodule Membrane.RTC.Engine.DisplayManager do
     engine_pid = opts[:engine]
     ets_name = opts[:ets_name]
     ets_name = :"#{ets_name}"
-    :ets.new(ets_name, [:set, :public, :named_table])
+
+    if :ets.whereis(ets_name) == :undefined do
+      :ets.new(ets_name, [:set, :public, :named_table])
+    end
+
     display_manager = self()
 
     track_priorities_calc =
@@ -46,14 +50,10 @@ defmodule Membrane.RTC.Engine.DisplayManager do
   end
 
   @impl true
-  def handle_info({:vad_notification, endpoint_name, :speech}, state) do
-    state = maybe_calculate_priority(state, [{:speech, endpoint_name} | state.vads])
-    {:noreply, state}
-  end
+  def handle_info({:vad_notification, endpoint_name, vad_value}, state) do
+    new_vad = {vad_value, endpoint_name, System.monotonic_time()}
 
-  @impl true
-  def handle_info({:vad_notification, endpoint_name, :silence}, state) do
-    state = %{state | vads: [{:silence, endpoint_name, System.monotonic_time()} | state.vads]}
+    state = maybe_calculate_priority(state, [new_vad | state.vads])
     {:noreply, state}
   end
 
@@ -220,11 +220,8 @@ defmodule Membrane.RTC.Engine.DisplayManager do
 
     ends_of_speech =
       Enum.reduce(notifications, ends_of_speech, fn
-        {:speech, endpoint_name}, acc ->
-          Map.put(acc, endpoint_name, :speaking)
-
-        {:silence, endpoint_name, timestamp}, acc ->
-          Map.put(acc, endpoint_name, timestamp)
+        {vad_value, endpoint_name, timestamp}, acc ->
+          Map.put(acc, endpoint_name, {vad_value, timestamp})
 
         {:new_track, endpoint_name}, acc ->
           Map.put_new(acc, endpoint_name, nil)
@@ -236,17 +233,12 @@ defmodule Membrane.RTC.Engine.DisplayManager do
           acc
       end)
 
-    current_time = System.monotonic_time()
-
     ordered_endpoint_names =
       ends_of_speech
-      |> Enum.map(fn
-        {endpoint_name, :speaking} -> {endpoint_name, 1}
-        {endpoint_name, nil} -> {endpoint_name, 0}
-        {endpoint_name, timestamp} -> {endpoint_name, timestamp / current_time}
-      end)
-      |> Enum.sort_by(fn {_endpoint_name, time} -> time end)
+      |> Enum.sort_by(fn {_endpoint_name, time} -> time end, &sorting_vads/2)
       |> Enum.map(fn {endpoint_name, _time} -> endpoint_name end)
+
+    IO.inspect(ordered_endpoint_names, label: :ordered_endpoint_names)
 
     ordered_tracks =
       Enum.flat_map(ordered_endpoint_names, fn endpoint_name ->
@@ -278,6 +270,13 @@ defmodule Membrane.RTC.Engine.DisplayManager do
 
     track_priorities
   end
+
+  defp sorting_vads(_vad, nil), do: true
+  defp sorting_vads(nil, _vad), do: false
+  defp sorting_vads({:silence, timestamp1}, {:silence, timestamp2}), do: timestamp1 > timestamp2
+  defp sorting_vads({:silence, _timestamp1}, {:speech, _timestamp2}), do: false
+  defp sorting_vads({:speech, _timestamp1}, {:silence, _timestamp2}), do: true
+  defp sorting_vads({:speech, timestamp1}, {:speech, timestamp2}), do: timestamp1 < timestamp2
 
   defp update_ets(endpoint_name_to_tracks, all_video_tracks, ets_name) do
     empty_track_id_to_endpoints = Map.new(all_video_tracks, &{&1.id, []})

--- a/lib/membrane_rtc_engine/display_manager/endpoint_manager.ex
+++ b/lib/membrane_rtc_engine/display_manager/endpoint_manager.ex
@@ -53,9 +53,7 @@ defmodule Membrane.RTC.Engine.EndpointManager do
           type :: :inbound_tracks | :outbound_tracks
         ) :: t()
   def add_tracks(endpoint, tracks, type) do
-    result = Map.update!(endpoint, type, &update_tracks(tracks, &1))
-
-    result
+    Map.update!(endpoint, type, &update_tracks(tracks, &1))
   end
 
   @spec remove_tracks(

--- a/lib/membrane_rtc_engine/display_manager/endpoint_manager.ex
+++ b/lib/membrane_rtc_engine/display_manager/endpoint_manager.ex
@@ -53,9 +53,9 @@ defmodule Membrane.RTC.Engine.EndpointManager do
           type :: :inbound_tracks | :outbound_tracks
         ) :: t()
   def add_tracks(endpoint, tracks, type) do
-    track_id_to_track = Map.fetch!(endpoint, type)
-    track_id_to_track = update_tracks(tracks, track_id_to_track)
-    Map.put(endpoint, type, track_id_to_track)
+    result = Map.update!(endpoint, type, &update_tracks(tracks, &1))
+
+    result
   end
 
   @spec remove_tracks(

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -321,12 +321,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       end
     end)
 
+    IO.inspect(new_outbound_tracks, label: :subscribe_tracks)
     send_if_not_nil(state.display_manager, {:subscribe_tracks, ctx.name, new_outbound_tracks})
     {:ok, state}
   end
 
   @impl true
   def handle_notification({:vad, val}, :endpoint_bin, ctx, state) do
+    IO.inspect({:vad, val, ctx.name}, label: :vad_notification)
     send(state.owner, {:vad_notification, val, ctx.name})
 
     send_if_not_nil(state.display_manager, {:vad_notification, ctx.name, val})

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -321,7 +321,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
       end
     end)
 
-    IO.inspect(new_outbound_tracks, label: :subscribe_tracks)
     send_if_not_nil(state.display_manager, {:subscribe_tracks, ctx.name, new_outbound_tracks})
     {:ok, state}
   end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -327,7 +327,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_notification({:vad, val}, :endpoint_bin, ctx, state) do
-    IO.inspect({:vad, val, ctx.name}, label: :vad_notification)
     send(state.owner, {:vad_notification, val, ctx.name})
 
     send_if_not_nil(state.display_manager, {:vad_notification, ctx.name, val})

--- a/lib/membrane_rtc_engine/tees/filter_tee.ex
+++ b/lib/membrane_rtc_engine/tees/filter_tee.ex
@@ -146,6 +146,13 @@ defmodule Membrane.RTC.Engine.FilterTee do
           MapSet.new()
       end
 
-    {:ok, %{state | forward_to: forward_to}}
+    new_forwards = MapSet.difference(forward_to, state.forward_to)
+
+    action =
+      if MapSet.size(new_forwards) != 0,
+        do: [event: {:input, %Membrane.KeyframeRequestEvent{}}],
+        else: []
+
+    {{:ok, action}, %{state | forward_to: forward_to}}
   end
 end


### PR DESCRIPTION
This PR fixes bugs from updating `membrane_core` to `0.10.0` in `FilterTee`. It also slightly changes how tracks are ordered in `DisplayManager`. The highest priority has a track of the longest speaking peer, the next in priority order is the silent peer, which is silent for the shortest time, and then with the least priority are peers which don't send VADs, because e.g: they don't negotiate them in SDP or don't have an audio track.
To test changes you can use this branch: 
https://github.com/membraneframework/membrane_videoroom/tree/test_display_manager
