### PR TITLE
Allow for bwe overuse in certain conditions

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
@@ -3,10 +3,55 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator do
   Behavior defining a set of functions for managing connection allocations for TrackReceivers.
 
   It is responsible for allocating connection bandwidth for track receivers and probing the connection.
+
+  # Message protocol
+
+  In addition to implementing the behavior, Each implementation of ConnectionAllocator should be aware of the
+  following message protocol.
+
+  `Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver` already implements proper handling of this message protocol.
+
+  ## Granting an allocation
+
+  `t:#{inspect(__MODULE__)}.AllocationGrantedNotification.t/0` message is sent to TrackReceiver when ConnectionAllocator
+  wants to grant an allocation. TrackReceiver is obligated to comply. This message can also be used to
+  force-lower the allocation of a particular TrackReceiver, skipping the negotiation flow.
+
+  ## Negotiating lower allocation
+  Whenever it is deemed necessary, ConnectionAllocator can send `t:decrease_allocation_request/0` to
+  selected TrackReceiver, to request that it lowers its allocation by unspecified amount.
+  Usually, this will mean that TrackReceiver selects a lower variant (if possible).
+  In response, TrackReceiver sends `t:decrease_allocation_request_response/0` to ConnectionAllocator.
+  If the request was accepted, TrackReceiver is obligated to request lower allocation
+  immediately after sending a reply.
+
+  ### Example of decrease allocation request message flow
+  ```
+  CA - Connection Allocator
+  TR - Track Receiver
+
+  CA -> TR: :decrease_your_allocation
+  TR -> CA: {:decrease_allocation_request, :accept}
+  TR calls `request_allocation/2` with lowered allocation
+  CA -> AllocationGrantedNotification
+  ```
   """
 
   alias Membrane.Buffer
   alias Membrane.RTC.Engine.Track
+
+  @typedoc """
+  Type describing a message sent by ConnectionAllocator to `Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver`
+  to request that they lower their allocation.
+  """
+  @type decrease_allocation_request() :: :decrease_your_allocation
+
+  @typedoc """
+  Type describing a message sent by  `Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver` to ConnectionAllocator
+  in response to `t:decrease_allocation_request/0`, in order to either accept or reject the request.
+  """
+  @type decrease_allocation_request_response() ::
+          {:decrease_allocation_request, :accept | :reject}
 
   @doc """
   A function that should be used by the WebRTC Endpoint to create an instance of ConnectionAllocator

--- a/lib/membrane_rtc_engine/endpoints/webrtc/variant_selector.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/variant_selector.ex
@@ -99,10 +99,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelector do
         # our initial allocation and we were not sending
         # anything except audio. As a result our bandwidth
         # estimation was starting from ~50kbps
-        #
-        # the solution to chose 2*variant_bitrates[:high]
-        # should allow us to send anything at start;
-        # we will adjust quality after next bwe
         :video -> 1.1 * variant_bitrates[:high]
       end
 
@@ -135,7 +131,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelector do
     |> perform_automatic_variant_selection()
   end
 
-  # TODO: doc
+  @doc """
+  Function called by TrackReceiver upon receiving `t:Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator.decrease_allocation_request/0`
+  from the ConnectionAllocator
+  """
   @spec decrease_allocation(t()) :: {t(), selector_action_t()}
   def decrease_allocation(%__MODULE__{} = selector) do
     reply = &send(selector.connection_allocator, {self(), {:decrease_allocation_request, &1}})

--- a/lib/membrane_rtc_engine/endpoints/webrtc/variant_selector.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/variant_selector.ex
@@ -103,7 +103,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelector do
         # the solution to chose 2*variant_bitrates[:high]
         # should allow us to send anything at start;
         # we will adjust quality after next bwe
-        :video -> 2 * variant_bitrates[:high]
+        :video -> 1.1 * variant_bitrates[:high]
       end
 
     connection_allocator_module.register_track_receiver(

--- a/test/membrane_rtc_engine/media_event_test.exs
+++ b/test/membrane_rtc_engine/media_event_test.exs
@@ -1,5 +1,5 @@
 defmodule Membrane.RTC.Engine.MediaEventTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Membrane.RTC.Engine.MediaEvent
 

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -6,7 +6,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
   alias Membrane.Time
 
   @initial_bandwidth_estimation 10_000
-  @padding_packet_size 8 * Membrane.RTP.Packet.padding_packet_size()
+  @padding_packet_size 8 * 256
 
   setup context do
     track = %{

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -1,5 +1,5 @@
 defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case
 
   alias Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator.AllocationGrantedNotification
   alias Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator
@@ -30,6 +30,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       [prober: prober]
     end
 
+    # This test is a little flaky
     test "correctly probes the connection in :maintain_allocation state", %{
       prober: prober,
       track: track
@@ -78,6 +79,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       refute_receive :send_padding_packet, 0
     end
 
+    # this test is a little flaky
     test "correctly probes the connection in :increase_allocation state", %{
       prober: prober,
       track: track

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -1,0 +1,269 @@
+defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
+  use ExUnit.Case, async: true
+
+  alias Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator.AllocationGrantedNotification
+  alias Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator
+  alias Membrane.Time
+
+  @initial_bandwidth_estimation 10_000
+  @padding_packet_size 8 * Membrane.RTP.Packet.padding_packet_size()
+
+  setup context do
+    track = %{
+      type: :video,
+      variants:
+        if(Map.get(context, :negotiable?, true),
+          do: [:high, :medium, :low],
+          else: [:high]
+        )
+    }
+
+    [track: track]
+  end
+
+  describe "RTPConnectionAllocator" do
+    setup do
+      {:ok, prober} = RTPConnectionAllocator.start_link()
+
+      RTPConnectionAllocator.update_bandwidth_estimation(prober, @initial_bandwidth_estimation)
+
+      [prober: prober]
+    end
+
+    test "correctly probes the connection in :maintain_allocation state", %{
+      prober: prober,
+      track: track
+    } do
+      requested_bandwidth = @initial_bandwidth_estimation
+      my_pid = self()
+
+      task =
+        spawn(fn ->
+          RTPConnectionAllocator.register_track_receiver(prober, 0, track)
+          RTPConnectionAllocator.request_allocation(prober, requested_bandwidth)
+          reply_to_send_padding_messages(my_pid, prober)
+          RTPConnectionAllocator.request_allocation(prober, 0)
+        end)
+
+      Process.sleep(100)
+      clear_inbox()
+
+      start_time = Time.monotonic_time()
+      Process.sleep(5_000)
+      send(task, :die)
+
+      duration = Time.monotonic_time() - start_time
+      duration_in_s = Ratio.to_float(Time.as_seconds(duration))
+
+      expected_amount_of_paddings =
+        Ratio.new(requested_bandwidth * duration_in_s, @padding_packet_size)
+        |> Ratio.to_float()
+        |> floor()
+        |> tap(&assert &1 > 1)
+
+      for i <- 1..expected_amount_of_paddings do
+        assert_receive :send_padding_packet,
+                       0,
+                       "Only received #{i - 1}/#{expected_amount_of_paddings}"
+
+        :ok
+      end
+
+      receive do
+        :send_padding_packet -> :ok
+      after
+        0 -> :ok
+      end
+
+      refute_receive :send_padding_packet, 0
+    end
+
+    test "correctly probes the connection in :increase_allocation state", %{
+      prober: prober,
+      track: track
+    } do
+      expected_probing_rate = @initial_bandwidth_estimation + 200_000
+      my_pid = self()
+
+      task =
+        spawn(fn ->
+          RTPConnectionAllocator.register_track_receiver(prober, 0, track)
+          RTPConnectionAllocator.request_allocation(prober, 999_999_999_999_999_999)
+          reply_to_send_padding_messages(my_pid, prober)
+          RTPConnectionAllocator.request_allocation(prober, 0)
+        end)
+
+      Process.sleep(100)
+      clear_inbox()
+
+      start_time = Time.monotonic_time()
+      Process.sleep(5_000)
+      send(task, :die)
+
+      duration = Time.monotonic_time() - start_time
+      duration_in_s = Ratio.to_float(Time.as_seconds(duration))
+
+      expected_amount_of_paddings =
+        Ratio.new(expected_probing_rate * duration_in_s, @padding_packet_size)
+        |> Ratio.to_float()
+        |> floor()
+        |> tap(&assert &1 > 1)
+
+      for i <- 1..expected_amount_of_paddings do
+        assert_receive :send_padding_packet,
+                       0,
+                       "Only received #{i - 1}/#{expected_amount_of_paddings}"
+
+        :ok
+      end
+
+      receive do
+        :send_padding_packet -> :ok
+      after
+        0 -> :ok
+      end
+
+      refute_receive :send_padding_packet, 0
+    end
+
+    test "Grants allocations if it has bandwidth for it", %{prober: prober, track: track} do
+      allocation = 1_000
+      RTPConnectionAllocator.register_track_receiver(prober, 0, track)
+      RTPConnectionAllocator.request_allocation(prober, allocation)
+      assert_receive %AllocationGrantedNotification{allocation: ^allocation}
+    end
+
+    test "starts probing when it doesn't have enough bandwidth to grant the allocation and grants it when allocation becomes available",
+         %{prober: prober, track: track} do
+      allocation = @initial_bandwidth_estimation * 2
+      RTPConnectionAllocator.register_track_receiver(prober, 0, track)
+      RTPConnectionAllocator.request_allocation(prober, allocation)
+      assert_receive :send_padding_packet
+
+      RTPConnectionAllocator.update_bandwidth_estimation(prober, allocation * 2)
+      assert_receive %AllocationGrantedNotification{allocation: ^allocation}
+    end
+  end
+
+  describe "RTPConnectionAllocator does" do
+    setup %{track: track} = _context do
+      prober = %RTPConnectionAllocator{}
+
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast(
+          {:bandwidth_estimation, @initial_bandwidth_estimation},
+          prober
+        )
+
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast({:hello, self(), 10_000, track}, prober)
+
+      [prober: prober]
+    end
+
+    test "switches to disallowed deficiency when bandwidth estimation lowers below allocated bandwidth",
+         %{prober: prober} do
+      send(self(), {self(), {:decrease_allocation_request, :accept}})
+      {:noreply, prober} = RTPConnectionAllocator.handle_cast({:bandwidth_estimation, 0}, prober)
+      assert prober.prober_status == :disallowed_bandwidth_deficiency
+      assert_receive :decrease_your_allocation, 0
+
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast({:request_allocation, self(), 0}, prober)
+
+      assert prober.prober_status == :maintain_estimation
+      refute_receive :decrease_your_allocation, 0
+    end
+
+    test "switches to disallowed deficiency from allowed deficiency when bandwidth decreases below allocated bandwidth",
+         %{prober: prober, track: track} do
+      # Get to allowed deficiency
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast(
+          {:hello, self(), 100_000_000, %{track | variants: [:high]}},
+          prober
+        )
+
+      assert prober.prober_status == :allowed_bandwidth_deficiency
+
+      {:noreply, prober} = RTPConnectionAllocator.handle_cast({:bandwidth_estimation, 0}, prober)
+      assert prober.prober_status == :disallowed_bandwidth_deficiency
+    end
+
+    test "stays in allowed deficiency if estimation increases", %{track: track, prober: prober} do
+      # Get to allowed deficiency
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast(
+          {:hello, self(), 100_000_000, %{track | variants: [:high]}},
+          prober
+        )
+
+      assert prober.prober_status == :allowed_bandwidth_deficiency
+
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast(
+          {:bandwidth_estimation, prober.available_bandwidth + 200_000},
+          prober
+        )
+
+      assert prober.prober_status == :allowed_bandwidth_deficiency
+    end
+
+    test "switches to increase estimation mode when there is a TR that wants higher allocation",
+         %{prober: prober} do
+      request = 10_000_000
+
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast({:request_allocation, self(), request}, prober)
+
+      assert prober.prober_status == :increase_estimation
+
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast({:bandwidth_estimation, 2 * request}, prober)
+
+      assert prober.prober_status == :maintain_estimation
+      assert_receive %AllocationGrantedNotification{allocation: ^request}
+    end
+
+    @tag negotiable?: false
+    test "switches to allowed deficiency_mode when non-negotiable track raises allocation over available bandwidth",
+         %{prober: prober} do
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast({:request_allocation, self(), 1_000_000_000}, prober)
+
+      assert prober.prober_status == :allowed_bandwidth_deficiency
+    end
+
+    test "switches to allowed deficiency mode when new track receiver shows up", %{
+      track: track,
+      prober: prober
+    } do
+      {:noreply, prober} =
+        RTPConnectionAllocator.handle_cast({:hello, self(), 1_000_000, track}, prober)
+
+      assert prober.prober_status == :allowed_bandwidth_deficiency
+    end
+  end
+
+  defp clear_inbox(acc \\ 0) do
+    receive do
+      _message ->
+        clear_inbox(acc + 1)
+    after
+      0 ->
+        acc
+    end
+  end
+
+  defp reply_to_send_padding_messages(parent, prober) do
+    receive do
+      :send_padding_packet ->
+        RTPConnectionAllocator.probe_sent(prober)
+        send(parent, :send_padding_packet)
+        reply_to_send_padding_messages(parent, prober)
+
+      :die ->
+        :ok
+    end
+  end
+end

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -145,7 +145,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
     end
   end
 
-  describe "RTPConnectionAllocator does" do
+  describe "RTPConnectionAllocator prober state" do
     setup %{track: track} = _context do
       prober = %RTPConnectionAllocator{}
 

--- a/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
@@ -1,5 +1,5 @@
 defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import Bitwise
 
   import Membrane.RTC.Engine.Support.Utils

--- a/test/membrane_rtc_engine/webrtc/variant_selector_test.exs
+++ b/test/membrane_rtc_engine/webrtc/variant_selector_test.exs
@@ -1,7 +1,13 @@
 defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Membrane.RTC.Engine.Endpoint.WebRTC.{DefaultConnectionAllocator, VariantSelector}
+
+  @variant_bitrates %{
+    high: 1_500_000,
+    medium: 500_000,
+    low: 150_000
+  }
 
   test "VariantSelector selects another variant when currently used variant becomes inactive" do
     selector = create_selector()
@@ -9,6 +15,12 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
     assert {_selector, {:request, :low}} = VariantSelector.variant_inactive(selector, :medium)
   end
 
+  # Skip explanation:
+  # After introducing automatic variant switching, this feature seems to
+  # be a out of date. This behavior will be either achieved
+  # or overwritten by the desire to always send the highest possible or target
+  # variant, that fits the bandwidth allocation
+  @tag :skip
   test "VariantSelector selects variant being used before it became inactive" do
     selector = create_selector()
 
@@ -23,7 +35,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
     selector = create_selector()
 
     assert {selector, {:request, :medium}} = VariantSelector.variant_inactive(selector, :high)
-    assert {selector, {:request, :medium}} = VariantSelector.set_target_variant(selector, :medium)
+    assert {selector, :noop} = VariantSelector.set_target_variant(selector, :medium)
 
     selector = VariantSelector.set_current_variant(selector, :medium)
 
@@ -40,6 +52,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
     assert {_selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
   end
 
+  @tag :skip
   test "VariantSelector doesn't select a new variant when not currently used variant is marked as inactive" do
     selector = create_selector()
 
@@ -47,13 +60,108 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
     assert {_selector, :noop} = VariantSelector.variant_inactive(selector, :low)
   end
 
-  test "VariantSelector selects a new variant when it is better than currently used variant and while waiting for the target variant" do
-    selector = VariantSelector.new(%{type: :video}, DefaultConnectionAllocator, self(), :high)
-    selector = %{selector | current_allocation: 9_999_999_999_999}
+  describe "Automatic variant selection in VariantSelector" do
+    setup do
+      [
+        selector:
+          VariantSelector.new(
+            %{type: :video},
+            Membrane.RTC.Engine.Endpoint.WebRTC.TestConnectionAllocator,
+            self(),
+            :high
+          )
+      ]
+    end
 
-    assert {selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
-    assert {selector, {:request, :medium}} = VariantSelector.variant_active(selector, :medium)
-    assert {_selector, {:request, :high}} = VariantSelector.variant_active(selector, :high)
+    test "accepts any variant before receiving first allocation", %{selector: selector} do
+      Enum.each([:low, :medium, :high], fn variant ->
+        assert {_selector, {:request, ^variant}} =
+                 VariantSelector.variant_active(selector, variant)
+      end)
+    end
+
+    test "frees unused allocation", %{selector: selector} do
+      assert {_selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
+      assert_allocation_requested(:low)
+    end
+
+    test "requests allocation for higher variant", %{selector: selector} do
+      assert {selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
+      assert_allocation_requested(:low)
+      assert {_selector, :noop} = VariantSelector.variant_active(selector, :medium)
+      assert_allocation_requested(:medium)
+    end
+
+    test "doesn't select a higher variant right after lowering its allocation, before receiving confirmation from the Allocator",
+         %{selector: selector} do
+      assert {selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
+      assert_allocation_requested(:low)
+      assert {_selector, :noop} = VariantSelector.variant_active(selector, :medium)
+    end
+
+    test "selects the highest possible variant", %{selector: selector} do
+      variants = [:low, :medium, :high]
+
+      # activate all variants
+      selector =
+        Enum.reduce(variants, selector, fn variant, selector ->
+          assert {selector, _action} = VariantSelector.variant_active(selector, variant)
+          selector
+        end)
+
+      # ensuring correct initial conditions - selector now has the allocation only for low
+      assert selector.queued_variant == :low
+      assert_allocation_requested(:low)
+
+      # slowly increase the allocation
+      Enum.reduce([:medium, :high], selector, fn variant, selector ->
+        allocation = @variant_bitrates[variant] * 1.1
+        assert_allocation_requested(variant)
+
+        assert {selector, {:request, ^variant}} =
+                 VariantSelector.set_bandwidth_allocation(selector, allocation)
+
+        selector
+      end)
+    end
+
+    test "requests to stop the track when allocation is forcefully lowered", %{selector: selector} do
+      assert {selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
+      assert {_selector, :stop} = VariantSelector.set_bandwidth_allocation(selector, 0)
+    end
+
+    test "refuses to lower the allocation before receiving the first variant", %{
+      selector: selector
+    } do
+      assert {_selector, :noop} = VariantSelector.decrease_allocation(selector)
+      assert_receive {_pid, {:decrease_allocation_request, :reject}}
+    end
+
+    test "refuses to lower the allocation when on low", %{selector: selector} do
+      assert {selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
+      assert {_selector, :noop} = VariantSelector.decrease_allocation(selector)
+      assert_receive {_pid, {:decrease_allocation_request, :reject}}
+    end
+
+    test "lowers the allocation when on medium and it is requested", %{selector: selector} do
+      assert {selector, {:request, :low}} = VariantSelector.variant_active(selector, :low)
+      assert_allocation_requested(:low)
+      assert {selector, :noop} = VariantSelector.variant_active(selector, :medium)
+      assert_allocation_requested(:medium)
+
+      assert {selector, {:request, :medium}} =
+               VariantSelector.set_bandwidth_allocation(
+                 selector,
+                 @variant_bitrates[:medium] * 1.1
+               )
+
+      selector = VariantSelector.set_current_variant(selector, :medium)
+
+      assert {selector, {:request, :low}} = VariantSelector.decrease_allocation(selector)
+      assert_receive {_pid, {:decrease_allocation_request, :accept}}
+      VariantSelector.set_current_variant(selector, :low)
+      assert_allocation_requested(:low)
+    end
   end
 
   defp create_selector() do
@@ -67,5 +175,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
     assert {selector, :noop} = VariantSelector.variant_active(selector, :medium)
     assert {selector, :noop} = VariantSelector.variant_active(selector, :low)
     selector
+  end
+
+  defp assert_allocation_requested(variant) do
+    bitrate = @variant_bitrates[variant] * 1.1
+    assert_receive {:request_allocation, _pid, ^bitrate}
   end
 end

--- a/test/membrane_rtc_engine/webrtc/variant_tracker_test.exs
+++ b/test/membrane_rtc_engine/webrtc/variant_tracker_test.exs
@@ -1,5 +1,5 @@
 defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantTrackerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
 
   alias Membrane.RTC.Engine.Endpoint.WebRTC.VariantTracker
 

--- a/test/membrane_rtc_engine/webrtc/vp8_munger_test.exs
+++ b/test/membrane_rtc_engine/webrtc/vp8_munger_test.exs
@@ -1,5 +1,5 @@
 defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VP8MungerTest do
-  use ExUnit.Case
+  use ExUnit.Case, async: true
   import Bitwise
 
   import Membrane.RTC.Engine.Support.Utils

--- a/test/support/webrtc/test_connection_allocator.ex
+++ b/test/support/webrtc/test_connection_allocator.ex
@@ -1,0 +1,34 @@
+defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TestConnectionAllocator do
+  @moduledoc false
+  @behaviour Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator
+
+  @impl true
+  def start_link(), do: {:ok, self()}
+
+  @impl true
+  def register_track_receiver(allocator, bandwidth, track) do
+    send(allocator, {:register_tr, self(), bandwidth, track})
+    :ok
+  end
+
+  @impl true
+  def request_allocation(allocator, allocation) do
+    send(allocator, {:request_allocation, self(), allocation})
+    :ok
+  end
+
+  @impl true
+  def update_bandwidth_estimation(_allocator, _estimation) do
+    raise "Unimplemented!"
+  end
+
+  @impl true
+  def buffer_sent(_allocator, _buffer) do
+    :ok
+  end
+
+  @impl true
+  def probe_sent(_allocator) do
+    :ok
+  end
+end


### PR DESCRIPTION
This PR allows for bwe overuse when adding a new track. This way, when we e.g. start a screen share we don't have to limit the bandwidth already granted  to some other tracks.