### PR TITLE
Enable negotiable mode 100ms after start of stream to allow instantly reaching target variant

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
@@ -89,7 +89,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator do
   @doc """
   A function used by VariantSelector to change it's negotiability status.
 
-  TrackReceiver is considered negotiable if it is both capable of decreasing it's bandwidth usage and, in principal, allowed to do so.
+  TrackReceiver is considered negotiable if it is both capable of decreasing its bandwidth usage and, in principal, allowed to do so.
   """
   @callback set_negotiability_status(pid(), boolean()) :: :ok
 end

--- a/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
@@ -71,7 +71,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator do
   @doc """
   Function called by the TrackReceiver to register itself in the allocator
   """
-  @callback register_track_receiver(pid(), number(), Track.t()) :: :ok
+  @callback register_track_receiver(pid(), number(), Track.t(), Keyword.t()) :: :ok
 
   @doc """
   A function called by the endpoint, to update the bandwidth estimation in the allocator
@@ -85,4 +85,11 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator do
   to the track receiver that gets new allocation.
   """
   @callback request_allocation(pid(), number()) :: :ok
+
+  @doc """
+  A function used by VariantSelector to change it's negotiability status.
+
+  TrackReceiver is considered negotiable if it is both capable of decreasing it's bandwidth usage and, in principal, allowed to do so.
+  """
+  @callback set_negotiability_status(pid(), boolean()) :: :ok
 end

--- a/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/connection_allocator.ex
@@ -87,7 +87,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator do
   @callback request_allocation(pid(), number()) :: :ok
 
   @doc """
-  A function used by VariantSelector to change it's negotiability status.
+  Function used to change the negotiability status of the TrackReceiver.
 
   TrackReceiver is considered negotiable if it is both capable of decreasing its bandwidth usage and, in principal, allowed to do so.
   """

--- a/lib/membrane_rtc_engine/endpoints/webrtc/noop_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/noop_connection_allocator.ex
@@ -12,7 +12,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.NoOpConnectionAllocator do
   def start_link(), do: {:ok, nil}
 
   @impl true
-  def register_track_receiver(_manager, _bandwidth, _track), do: :ok
+  def register_track_receiver(_manager, _bandwidth, _track, _options \\ []), do: :ok
 
   @impl true
   def update_bandwidth_estimation(_manager, _estimation), do: :ok
@@ -28,4 +28,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.NoOpConnectionAllocator do
     send(self(), %AllocationGrantedNotification{allocation: requested_allocation})
     :ok
   end
+
+  @impl true
+  def set_negotiability_status(_manager, _value), do: :ok
 end

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -102,7 +102,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
   def handle_cast({:bandwidth_estimation, estimation}, state) do
     Logger.info("Received bandwidth estimation of #{estimation / 1024} kbps")
 
-    estimation_increasing? = state.available_bandwidth == :unknown or estimation >= state.available_bandwidth
+    estimation_increasing? =
+      state.available_bandwidth == :unknown or estimation >= state.available_bandwidth
 
     state =
       state

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -137,9 +137,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
     # This is the very first call that we're getting from the Track Receiver
     # It is already sending some variant, so whatever bandwidth they are using will be initially allocated
     # without question
-
-    Logger.warn("New Track Receiver: #{inspect(pid)}")
-
     Process.monitor(pid)
 
     negotiable? =

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -102,10 +102,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
   def handle_cast({:bandwidth_estimation, estimation}, state) do
     Logger.info("Received bandwidth estimation of #{estimation / 1024} kbps")
 
-    estimation_increasing? =
-      if state.available_bandwidth == :unknown,
-        do: true,
-        else: estimation >= state.available_bandwidth
+    estimation_increasing? = state.available_bandwidth == :unknown or estimation >= state.available_bandwidth
 
     state =
       state

--- a/lib/membrane_rtc_engine/endpoints/webrtc/track_receiver.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/track_receiver.ex
@@ -147,6 +147,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
   @impl true
   def handle_prepared_to_playing(_ctx, %{keyframe_request_interval: interval} = state) do
     actions = if interval, do: [start_timer: {:request_keyframe, interval}], else: []
+    Process.send_after(self(), :change_to_adaptive, 100)
     {{:ok, actions}, state}
   end
 
@@ -216,6 +217,12 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
       end
 
     {{:ok, actions}, state}
+  end
+
+  @impl true
+  def handle_other(:change_to_adaptive, _ctx, state) do
+    VariantSelector.set_negotiable(state.selector, true)
+    {:ok, state}
   end
 
   @impl true

--- a/lib/membrane_rtc_engine/endpoints/webrtc/track_receiver.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/track_receiver.ex
@@ -147,8 +147,13 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
   @impl true
   def handle_prepared_to_playing(_ctx, %{keyframe_request_interval: interval} = state) do
     actions = if interval, do: [start_timer: {:request_keyframe, interval}], else: []
-    Process.send_after(self(), :change_to_adaptive, 100)
     {{:ok, actions}, state}
+  end
+
+  @impl true
+  def handle_start_of_stream(:input, _ctx, state) do
+    Process.send_after(self(), :change_to_adaptive, 100)
+    {:ok, state}
   end
 
   @impl true
@@ -233,6 +238,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
       """)
     end
 
+    Membrane.Logger.debug("Setting target variant #{variant}")
+
     {selector, selector_action} = VariantSelector.set_target_variant(state.selector, variant)
     actions = handle_selector_action(selector_action)
     {{:ok, actions}, %{state | selector: selector}}
@@ -256,7 +263,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
 
   @impl true
   def handle_other(:send_padding_packet, _ctx, state) do
-    Process.send_after(self(), :send_padding_packet, 10)
+    Process.send_after(self(), :send_padding_packet, 100)
     {:ok, state}
   end
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc/track_receiver.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/track_receiver.ex
@@ -43,7 +43,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
   @typedoc """
   Messages that can be sent to TrackReceiver to control its behavior.
   """
-  @type control_messages() :: set_target_variant()
+  @type control_messages() :: set_target_variant() | set_negotiable?()
 
   @typedoc """
   Changes target track variant.
@@ -52,6 +52,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
   whenever it is active.
   """
   @type set_target_variant() :: {:set_target_variant, Track.variant()}
+
+  @typedoc """
+  Changes negotiability status of the TrackReceiver.
+
+  Negotiability refers to the setting in `Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator`
+  that determines if the allocation for the TrackReceiver can be negotiated.
+  """
+  @type set_negotiable?() :: {:set_negotiable?, boolean()}
 
   @typedoc """
   Notifications that TrackReceiver emits.
@@ -111,7 +119,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
                 Trying to enable negotiability for tracks that are inherently non-negotiable, also
                 known as non-simulcast tracks, will result in a crash.
 
-                This value can later be changed by sending a `{:set_negotiable?, boolean()}` message to this Element.
+                This value can later be changed by sending a `set_negotiable?/0` control message to this Element.
                 """
               ]
 
@@ -162,11 +170,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackReceiver do
   def handle_prepared_to_playing(_ctx, %{keyframe_request_interval: interval} = state) do
     actions = if interval, do: [start_timer: {:request_keyframe, interval}], else: []
     {{:ok, actions}, state}
-  end
-
-  @impl true
-  def handle_start_of_stream(:input, _ctx, state) do
-    {:ok, state}
   end
 
   @impl true

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -583,6 +583,11 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   end
 
   @impl true
+  def handle_element_start_of_stream(_element, _ctx, state) do
+    {:ok, state}
+  end
+
+  @impl true
   def handle_pad_removed(Pad.ref(:input, track_id), _ctx, state) do
     {{:ok, remove_child: {:track_receiver, track_id}}, state}
   end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -532,9 +532,9 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
     if length(track.variants) > 1 do
       # Allocation negotiability is only applicable to simulcast tracks
-      # We wait 100ms to enable it to enable reaching a target variant at the beginning of the stream
+      # We wait 500ms to enable it to enable reaching a target variant at the beginning of the stream
       # for better user experience.
-      Process.send_after(self(), {:enable_negotiability, track_id}, 100)
+      Process.send_after(self(), {:enable_negotiability, track_id}, 500)
     end
 
     {{:ok, spec: %ParentSpec{log_metadata: state.log_metadata, links: links}}, state}

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -523,8 +523,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
         track: track,
         initial_target_variant: initial_target_variant,
         connection_allocator: state.connection_prober,
-        connection_allocator_module: @connection_prober,
-        allocation_negotiable?: false
+        connection_allocator_module: @connection_prober
       })
       |> via_in(pad, options: [use_payloader?: false])
       |> to(:endpoint_bin)

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -178,7 +178,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       assert {:noreply, prober} =
                RTPConnectionAllocator.handle_cast({:request_allocation, self(), 0}, prober)
 
-      assert prober.prober_status == :maintain_estimation
+      assert prober.prober_status == :maintain_allocation
       refute_receive :decrease_your_allocation, 0
     end
 
@@ -216,7 +216,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       assert prober.prober_status == :allowed_overuse
     end
 
-    test "switches to :increase_estimation upon allocation request and reverts back to :maintain_estimation after granting allocation",
+    test "switches to :increase_estimation upon allocation request and reverts back to :maintain_allocation after granting allocation",
          %{prober: prober} do
       request = 10_000_000
 
@@ -228,7 +228,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       {:noreply, prober} =
         RTPConnectionAllocator.handle_cast({:bandwidth_estimation, 2 * request}, prober)
 
-      assert prober.prober_status == :maintain_estimation
+      assert prober.prober_status == :maintain_allocation
       assert_receive %AllocationGrantedNotification{allocation: ^request}
     end
 

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -157,7 +157,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
         )
 
       {:noreply, prober} =
-        RTPConnectionAllocator.handle_cast({:hello, self(), 10_000, track}, prober)
+        RTPConnectionAllocator.handle_cast(
+          {:register_track_receiver, self(), 10_000, track, []},
+          prober
+        )
 
       [prober: prober]
     end
@@ -184,7 +187,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       # Get to allowed overuse
       {:noreply, prober} =
         RTPConnectionAllocator.handle_cast(
-          {:hello, self(), 100_000_000, %{track | variants: [:high]}},
+          {:register_track_receiver, self(), 100_000_000, %{track | variants: [:high]}, []},
           prober
         )
 
@@ -198,7 +201,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       # Get to allowed overuse
       {:noreply, prober} =
         RTPConnectionAllocator.handle_cast(
-          {:hello, self(), 100_000_000, %{track | variants: [:high]}},
+          {:register_track_receiver, self(), 100_000_000, %{track | variants: [:high]}, []},
           prober
         )
 
@@ -243,7 +246,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       prober: prober
     } do
       {:noreply, prober} =
-        RTPConnectionAllocator.handle_cast({:hello, self(), 1_000_000, track}, prober)
+        RTPConnectionAllocator.handle_cast(
+          {:register_track_receiver, self(), 1_000_000, track, []},
+          prober
+        )
 
       assert prober.prober_status == :allowed_overuse
     end

--- a/test/membrane_rtc_engine/webrtc/variant_selector_test.exs
+++ b/test/membrane_rtc_engine/webrtc/variant_selector_test.exs
@@ -65,10 +65,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
       [
         selector:
           VariantSelector.new(
-            %{type: :video},
+            %{type: :video, variants: [:low, :medium, :high]},
             Membrane.RTC.Engine.Endpoint.WebRTC.TestConnectionAllocator,
             self(),
-            :high
+            initial_target_variant: :high
           )
       ]
     end
@@ -165,7 +165,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.VariantSelectorTest do
   end
 
   defp create_selector() do
-    selector = VariantSelector.new(%{type: :video}, NoOpConnectionAllocator, self(), :high)
+    selector =
+      VariantSelector.new(
+        %{type: :video, variants: [:low, :medium, :high]},
+        NoOpConnectionAllocator,
+        self(),
+        initial_target_variant: :high
+      )
+
     selector = %{selector | current_allocation: 9_999_999_999_999}
 
     assert {selector, {:request, :high}} = VariantSelector.variant_active(selector, :high)

--- a/test/support/webrtc/test_connection_allocator.ex
+++ b/test/support/webrtc/test_connection_allocator.ex
@@ -6,7 +6,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TestConnectionAllocator do
   def start_link(), do: {:ok, self()}
 
   @impl true
-  def register_track_receiver(allocator, bandwidth, track) do
+  def register_track_receiver(allocator, bandwidth, track, _options \\ []) do
     send(allocator, {:register_tr, self(), bandwidth, track})
     :ok
   end
@@ -30,5 +30,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TestConnectionAllocator do
   @impl true
   def probe_sent(_allocator) do
     :ok
+  end
+
+  @impl true
+  def set_negotiability_status(_allocator, _value) do
+    raise "unimplemented!"
   end
 end


### PR DESCRIPTION
This PR introduces an ability to temporarily disable automatic variant selection. This is done to allow starting on the target variant.