### PR TITLE
Fix sending EOS in TrackSender

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/webrtc/track_sender.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/track_sender.ex
@@ -264,9 +264,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TrackSender do
   end
 
   @impl true
-  def handle_end_of_stream(input_pad, _ctx, state) do
+  def handle_end_of_stream(input_pad, ctx, state) do
     output_pad = to_output_pad(input_pad)
-    {{:ok, end_of_stream: output_pad}, state}
+
+    if Map.has_key?(ctx.pads, output_pad) do
+      {{:ok, end_of_stream: output_pad}, state}
+    else
+      {:ok, state}
+    end
   end
 
   defp check_variant_status(variant, tracker, state) do

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -287,12 +287,21 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   end
 
   @impl true
-  def handle_notification({:removed_tracks, tracks}, :endpoint_bin, _ctx, state) do
+  def handle_notification({:removed_tracks, tracks}, :endpoint_bin, ctx, state) do
     tracks = Enum.map(tracks, &to_rtc_track(&1, Map.get(state.inbound_tracks, &1.id)))
     inbound_tracks = update_tracks(tracks, state.inbound_tracks)
 
-    {{:ok, notify: {:publish, {:removed_tracks, tracks}}},
-     %{state | inbound_tracks: inbound_tracks}}
+    track_senders =
+      tracks
+      |> Enum.map(&{:track_sender, &1.id})
+      |> Enum.filter(&Map.has_key?(ctx.children, &1))
+
+    actions = [
+      remove_child: track_senders,
+      notify: {:publish, {:removed_tracks, tracks}}
+    ]
+
+    {{:ok, actions}, %{state | inbound_tracks: inbound_tracks}}
   end
 
   @impl true
@@ -560,18 +569,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   end
 
   @impl true
-  def handle_pad_removed(Pad.ref(:output, {track_id, _variant}), ctx, state) do
-    # check if there are any variants that are still linked
-    track_linked? =
-      ctx.pads
-      |> Map.keys()
-      |> Enum.any?(&match?(Pad.ref(:output, {^track_id, _variant}), &1))
-
-    if track_linked? do
-      {:ok, state}
-    else
-      {{:ok, remove_child: {:track_sender, track_id}}, state}
-    end
+  def handle_pad_removed(Pad.ref(:output, {_track_id, _variant}), _ctx, state) do
+    {:ok, state}
   end
 
   defp handle_custom_media_event(%{type: :sdp_offer, data: data}, ctx, state) do


### PR DESCRIPTION
Sometimes it happens that TS sends EOS on non-existing output pad. Always when leaving a room.

My hypothesis is that when we remove endpoint and corresponding tee it might happen that we will remove bin's output pad before sending EOS. Unfortunately I couldn't reproduce the issue with custom logs that would confirm I am right.