### PR TITLE
Fix freed bandwidth not being properly reallocated

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -249,8 +249,9 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
     state =
       state
       |> Map.update!(:allocated_bandwidth, &(&1 - tr_metadata.current_allocation))
+      |> maybe_change_overuse_status(state.prober_status == :allowed_overuse)
       |> update_allocations()
-      |> update_status()
+      |> maybe_change_probing_status()
 
     {:noreply, state}
   end

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -135,7 +135,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
       refute_receive %AllocationGrantedNotification{allocation: ^allocation}
     end
 
-    test "reallocates bandwidth of dieing TrackReceiver", %{track: track, prober: prober} do
+    test "reallocates bandwidth of terminating TrackReceiver", %{track: track, prober: prober} do
       RTPConnectionAllocator.update_bandwidth_estimation(prober, 1000)
 
       tr1 = mock_track_receiver(prober, 500, track)


### PR DESCRIPTION
There was an error in handling a `DOWN` message from the monitored TrackReceiver, related to managing `prober_status`, that caused improperly reallocating of bandwidth that was freed by the death of the TrackReceiver.