### PR TITLE
Drop duplicated sequence numbers in RTP Munger [RTC-22]

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger.ex
@@ -142,7 +142,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger do
 
     seq_num_diff = buffer.metadata.rtp.sequence_number - rtp_munger.highest_incoming_seq_num
 
-    if seq_num_diff > -(1 <<< 15) and seq_num_diff < 0 do
+    if seq_num_diff > -(1 <<< 15) and seq_num_diff <= 0 do
       # out-of-order - update its sequence number
       # and timestamp without updating munger
       # 1 <<< 15 represents half of maximal sequence number

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger.ex
@@ -153,8 +153,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger do
       # scenario in which the difference between subsequent sequence numbers
       # is equal to 0 - 65 536 = -65 536 - such packet cannot be
       # considered as out-of-order
-      case Cache.get(rtp_munger.cache, buffer.metadata.rtp.sequence_number) do
-        {:ok, seq_num} ->
+      case Cache.get_and_remove(rtp_munger.cache, buffer.metadata.rtp.sequence_number) do
+        {:ok, seq_num, cache} ->
+          rtp_munger = %{rtp_munger | cache: cache}
+
           metadata =
             buffer.metadata
             |> update_in([:rtp, :timestamp], &calculate_timestamp(&1, rtp_munger))

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger.ex
@@ -142,57 +142,62 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger do
 
     seq_num_diff = buffer.metadata.rtp.sequence_number - rtp_munger.highest_incoming_seq_num
 
-    if seq_num_diff > -(1 <<< 15) and seq_num_diff <= 0 do
-      # out-of-order - update its sequence number
-      # and timestamp without updating munger
-      # 1 <<< 15 represents half of maximal sequence number
-      # so we detect out-of-order packet when the difference is
-      # high enough (-32 768; 0)
-      #
-      # to understand this more consider sequence number rollover
-      # scenario in which the difference between subsequent sequence numbers
-      # is equal to 0 - 65 536 = -65 536 - such packet cannot be
-      # considered as out-of-order
-      case Cache.get_and_remove(rtp_munger.cache, buffer.metadata.rtp.sequence_number) do
-        {:ok, seq_num, cache} ->
-          rtp_munger = %{rtp_munger | cache: cache}
+    cond do
+      seq_num_diff == 0 ->
+        {rtp_munger, nil}
 
-          metadata =
-            buffer.metadata
-            |> update_in([:rtp, :timestamp], &calculate_timestamp(&1, rtp_munger))
-            |> put_in([:rtp, :sequence_number], seq_num)
+      seq_num_diff > -(1 <<< 15) and seq_num_diff < 0 ->
+        # out-of-order - update its sequence number
+        # and timestamp without updating munger
+        # 1 <<< 15 represents half of maximal sequence number
+        # so we detect out-of-order packet when the difference is
+        # high enough (-32 768; 0)
+        #
+        # to understand this more consider sequence number rollover
+        # scenario in which the difference between subsequent sequence numbers
+        # is equal to 0 - 65 536 = -65 536 - such packet cannot be
+        # considered as out-of-order
+        case Cache.get_and_remove(rtp_munger.cache, buffer.metadata.rtp.sequence_number) do
+          {:ok, seq_num, cache} ->
+            rtp_munger = %{rtp_munger | cache: cache}
 
-          {rtp_munger, %{buffer | metadata: metadata}}
+            metadata =
+              buffer.metadata
+              |> update_in([:rtp, :timestamp], &calculate_timestamp(&1, rtp_munger))
+              |> put_in([:rtp, :sequence_number], seq_num)
 
-        {:error, :not_found} ->
-          {rtp_munger, nil}
-      end
-    else
-      # in order but not necessarily contiguous packet
-      highest_incoming_seq_num = buffer.metadata.rtp.sequence_number
-      buffer = update_sn_ts.(buffer)
+            {rtp_munger, %{buffer | metadata: metadata}}
 
-      cache =
-        if seq_num_diff > 1 do
-          (rtp_munger.highest_incoming_seq_num + 1)..(highest_incoming_seq_num - 1)
-          |> Enum.reduce(rtp_munger.cache, fn seq_num, cache ->
-            Cache.push(cache, seq_num, calculate_seq_num(seq_num, rtp_munger))
-          end)
-        else
-          Cache.remove_outdated_entries(rtp_munger.cache, buffer.metadata.rtp.sequence_number)
+          {:error, :not_found} ->
+            {rtp_munger, nil}
         end
 
-      rtp_munger = %__MODULE__{
-        rtp_munger
-        | highest_incoming_seq_num: highest_incoming_seq_num,
-          last_seq_num: buffer.metadata.rtp.sequence_number,
-          last_timestamp: buffer.metadata.rtp.timestamp,
-          last_marker: buffer.metadata.rtp.marker,
-          last_packet_arrival: packet_arrival,
-          cache: cache
-      }
+      true ->
+        # in order but not necessarily contiguous packet
+        highest_incoming_seq_num = buffer.metadata.rtp.sequence_number
+        buffer = update_sn_ts.(buffer)
 
-      {rtp_munger, buffer}
+        cache =
+          if seq_num_diff > 1 do
+            (rtp_munger.highest_incoming_seq_num + 1)..(highest_incoming_seq_num - 1)
+            |> Enum.reduce(rtp_munger.cache, fn seq_num, cache ->
+              Cache.push(cache, seq_num, calculate_seq_num(seq_num, rtp_munger))
+            end)
+          else
+            Cache.remove_outdated_entries(rtp_munger.cache, buffer.metadata.rtp.sequence_number)
+          end
+
+        rtp_munger = %__MODULE__{
+          rtp_munger
+          | highest_incoming_seq_num: highest_incoming_seq_num,
+            last_seq_num: buffer.metadata.rtp.sequence_number,
+            last_timestamp: buffer.metadata.rtp.timestamp,
+            last_marker: buffer.metadata.rtp.marker,
+            last_packet_arrival: packet_arrival,
+            cache: cache
+        }
+
+        {rtp_munger, buffer}
     end
   end
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger/cache.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_munger/cache.ex
@@ -39,22 +39,6 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger.Cache do
     end
   end
 
-  @spec get(t(), non_neg_integer()) :: {:ok, non_neg_integer()} | {:error, :not_found}
-  def get(%__MODULE__{cache: cache}, from) do
-    cache
-    |> Enum.find(fn
-      {^from, _to} -> true
-      _otherwise -> false
-    end)
-    |> case do
-      nil ->
-        {:error, :not_found}
-
-      {^from, to} ->
-        {:ok, to}
-    end
-  end
-
   @spec get_and_remove(t(), non_neg_integer()) ::
           {:ok, non_neg_integer(), t()} | {:error, :not_found}
   def get_and_remove(%__MODULE__{} = state, from) do

--- a/test/membrane_rtc_engine/webrtc/rtp_munger/cache_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger/cache_test.exs
@@ -7,7 +7,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger.CacheTest do
   @history_size 64
 
   describe "RTPMunger.Cache" do
-    test "can retrieve stored information" do
+    test "can retrieve stored information only once" do
       entries =
         1..100
         |> Enum.map(&{&1, &1 + 200})
@@ -18,11 +18,11 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger.CacheTest do
         |> then(&%Cache{cache: &1})
 
       Enum.each(entries, fn {a, b} ->
-        assert Cache.get(cache, a) == {:ok, b}
-        assert {:ok, ^b, _cache} = Cache.get_and_remove(cache, a)
+        assert {:ok, ^b, cache} = Cache.get_and_remove(cache, a)
+        assert {:error, :not_found} == Cache.get_and_remove(cache, a)
       end)
 
-      assert {:error, :not_found} == Cache.get(cache, 123)
+      assert {:error, :not_found} == Cache.get_and_remove(cache, 123)
     end
 
     test "adds entries after rollover if they aren't too old" do
@@ -42,16 +42,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger.CacheTest do
         |> Cache.push(too_old_seq_num - 1, too_old_seq_num)
         |> Cache.push(1, 2)
 
-      assert {:error, :not_found} = Cache.get(cache, too_old_seq_num)
-    end
-
-    test "get_and_remove removes entries" do
-      cache =
-        Cache.new()
-        |> Cache.push(1, 1)
-
-      assert {:ok, 1, cache} = Cache.get_and_remove(cache, 1)
-      assert {:error, :not_found} == Cache.get_and_remove(cache, 1)
+      assert {:error, :not_found} = Cache.get_and_remove(cache, too_old_seq_num)
     end
   end
 end

--- a/test/membrane_rtc_engine/webrtc/rtp_munger/cache_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger/cache_test.exs
@@ -19,12 +19,13 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger.CacheTest do
 
       Enum.each(entries, fn {a, b} ->
         assert Cache.get(cache, a) == {:ok, b}
+        assert {:ok, ^b, _cache} = Cache.get_and_remove(cache, a)
       end)
 
       assert {:error, :not_found} == Cache.get(cache, 123)
     end
 
-    test "adds entries after rollover if the aren't too old" do
+    test "adds entries after rollover if they aren't too old" do
       cache =
         Cache.new()
         |> Cache.push(@max_seq_num - 2, 0)
@@ -42,6 +43,15 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMunger.CacheTest do
         |> Cache.push(1, 2)
 
       assert {:error, :not_found} = Cache.get(cache, too_old_seq_num)
+    end
+
+    test "get_and_remove removes entries" do
+      cache =
+        Cache.new()
+        |> Cache.push(1, 1)
+
+      assert {:ok, 1, cache} = Cache.get_and_remove(cache, 1)
+      assert {:error, :not_found} == Cache.get_and_remove(cache, 1)
     end
   end
 end

--- a/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
@@ -295,7 +295,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
   end
 
   test "RTP Munger drops out of order packets" do
-    encoding = generate_encoding_from_sequence(0, 0, [1, 2, 2, 3, 2])
+    encoding = generate_encoding_from_sequence(0, 0, [1, 2, 2, 3, 2, 5, 4, 4])
 
     rtp_munger =
       RTPMunger.new(90_000)
@@ -310,7 +310,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
     munged_encoding
     |> Enum.reject(&is_nil/1)
     |> Enum.map(& &1.metadata.rtp.sequence_number)
-    |> then(&assert &1 == [1, 2, 3])
+    |> then(&assert &1 == [1, 2, 3, 5, 4])
   end
 
   defp generate_encoding(seq_num_base, timestamp_base, packets_num) do

--- a/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
@@ -295,23 +295,22 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
   end
 
   test "RTP Munger drops out of order packets" do
-    encoding = generate_encoding_from_sequence(0,0,[1,2,2,3,2])
+    encoding = generate_encoding_from_sequence(0, 0, [1, 2, 2, 3, 2])
 
     rtp_munger =
       RTPMunger.new(90_000)
       |> RTPMunger.init(hd(encoding))
-    
+
     {_rtp_munger, munged_encoding} =
       Enum.reduce(encoding, {rtp_munger, []}, fn buffer, {rtp_munger, munged_encoding} ->
         {rtp_munger, munged_buffer} = RTPMunger.munge(rtp_munger, buffer)
         {rtp_munger, munged_encoding ++ [munged_buffer]}
       end)
 
-
     munged_encoding
     |> Enum.reject(&is_nil/1)
     |> Enum.map(& &1.metadata.rtp.sequence_number)
-    |> then(&assert &1 == [1,2,3])
+    |> then(&assert &1 == [1, 2, 3])
   end
 
   defp generate_encoding(seq_num_base, timestamp_base, packets_num) do

--- a/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
@@ -294,7 +294,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
     assert length(rest_munged_l_encoding) == 8
   end
 
-  test "RTP Munger drops out of order packets" do
+  test "RTP Munger drops duplicated packets" do
     encoding = generate_encoding_from_sequence(0, 0, [1, 2, 2, 3, 2, 5, 4, 4])
 
     rtp_munger =

--- a/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_munger_test.exs
@@ -294,8 +294,32 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
     assert length(rest_munged_l_encoding) == 8
   end
 
+  test "RTP Munger drops out of order packets" do
+    encoding = generate_encoding_from_sequence(0,0,[1,2,2,3,2])
+
+    rtp_munger =
+      RTPMunger.new(90_000)
+      |> RTPMunger.init(hd(encoding))
+    
+    {_rtp_munger, munged_encoding} =
+      Enum.reduce(encoding, {rtp_munger, []}, fn buffer, {rtp_munger, munged_encoding} ->
+        {rtp_munger, munged_buffer} = RTPMunger.munge(rtp_munger, buffer)
+        {rtp_munger, munged_encoding ++ [munged_buffer]}
+      end)
+
+
+    munged_encoding
+    |> Enum.reject(&is_nil/1)
+    |> Enum.map(& &1.metadata.rtp.sequence_number)
+    |> then(&assert &1 == [1,2,3])
+  end
+
   defp generate_encoding(seq_num_base, timestamp_base, packets_num) do
-    for i <- 0..(packets_num - 1), into: [] do
+    generate_encoding_from_sequence(seq_num_base, timestamp_base, 0..(packets_num - 1))
+  end
+
+  defp generate_encoding_from_sequence(seq_num_base, timestamp_base, sequence) do
+    Enum.map(sequence, fn i ->
       %Membrane.Buffer{
         payload: generate_random_payload(100),
         metadata: %{
@@ -306,7 +330,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPMungerTest do
           }
         }
       }
-    end
+    end)
   end
 
   defp swap(list, index1, index2) do


### PR DESCRIPTION
In the current state, RTP Munger won't always drop buffers with duplicated sequence numbers. In particular, the following scenario would result in the following output:
```
1,2,2,3,2 -> 1,2,2,3
```
Notice that only out-of-order duplicates were dropped. The behavior is inconsistent and might be causing a `replay fail` error in SRTP Encryptor (RTC-22).