### PR TITLE
[RTC-27] RTPConnectionAllocator doesn't terminate with parent endpoint

### DIFF
--- a/lib/membrane_rtc_engine/endpoints/webrtc/noop_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/noop_connection_allocator.ex
@@ -9,7 +9,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.NoOpConnectionAllocator do
   alias Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator.AllocationGrantedNotification
 
   @impl true
-  def start_link(), do: {:ok, nil}
+  def create(), do: {:ok, nil}
+
+  @impl true
+  def destroy(nil), do: :ok
 
   @impl true
   def register_track_receiver(_manager, _bandwidth, _track, _options \\ []), do: :ok

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -301,6 +301,13 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
     {:noreply, state}
   end
 
+  @impl true
+  def terminate(_reason, state) do
+    if state.bitrate_timer, do: :timer.cancel(state.bitrate_timer)
+
+    :ok
+  end
+  
   ## Helper functions
   defp stop_probing_timer(%__MODULE__{bitrate_timer: nil} = state), do: state
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -307,7 +307,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
 
     :ok
   end
-  
+
   ## Helper functions
   defp stop_probing_timer(%__MODULE__{bitrate_timer: nil} = state), do: state
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -64,8 +64,14 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
 
   @padding_packet_size 8 * 256
 
-  @impl true
+  @spec start_link() :: GenServer.on_start()
   def start_link(), do: GenServer.start_link(__MODULE__, [], [])
+
+  @impl true
+  def create(), do: start_link()
+
+  @impl true
+  def destroy(pid), do: GenServer.stop(pid)
 
   ## Public API
 

--- a/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc/rtp_connection_allocator.ex
@@ -64,11 +64,8 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocator do
 
   @padding_packet_size 8 * 256
 
-  @spec start_link() :: GenServer.on_start()
-  def start_link(), do: GenServer.start_link(__MODULE__, [], [])
-
   @impl true
-  def create(), do: start_link()
+  def create(), do: GenServer.start_link(__MODULE__, [], [])
 
   @impl true
   def destroy(pid), do: GenServer.stop(pid)

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -262,6 +262,17 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   end
 
   @impl true
+  def handle_playing_to_prepared(_ctx, state) do
+    try do
+      if Process.alive?(state.connection_prober) do
+        Process.exit(state.connection_prober, :kill)
+      end
+    end
+
+    {:ok, state}
+  end
+
+  @impl true
   def handle_notification({:estimation, estimations}, {:track_sender, track_id}, _ctx, state) do
     notification = %TrackNotification{
       track_id: track_id,

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -230,7 +230,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
   @impl true
   def handle_prepared_to_playing(ctx, state) do
     {:endpoint, endpoint_id} = ctx.name
-    {:ok, connection_prober} = state.connection_allocator_module.start_link()
+    {:ok, connection_prober} = state.connection_allocator_module.create()
 
     log_metadata = state.log_metadata ++ [webrtc_endpoint: endpoint_id]
 
@@ -263,7 +263,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_playing_to_prepared(_ctx, state) do
-    GenServer.stop(state.connection_prober)
+    state.connection_allocator_module.stop(state.connection_prober)
 
     {:ok, state}
   end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -263,11 +263,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_playing_to_prepared(_ctx, state) do
-    try do
-      if Process.alive?(state.connection_prober) do
-        Process.exit(state.connection_prober, :kill)
-      end
-    end
+    GenServer.stop(state.connection_allocator)
 
     {:ok, state}
   end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -263,7 +263,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_playing_to_prepared(_ctx, state) do
-    GenServer.stop(state.connection_allocator)
+    GenServer.stop(state.connection_prober)
 
     {:ok, state}
   end

--- a/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
+++ b/lib/membrane_rtc_engine/endpoints/webrtc_endpoint.ex
@@ -263,7 +263,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC do
 
   @impl true
   def handle_playing_to_prepared(_ctx, state) do
-    state.connection_allocator_module.stop(state.connection_prober)
+    state.connection_allocator_module.destroy(state.connection_prober)
 
     {:ok, state}
   end

--- a/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
+++ b/test/membrane_rtc_engine/webrtc/rtp_connection_allocator_test.exs
@@ -23,7 +23,7 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.RTPConnectionAllocatorTest do
 
   describe "RTPConnectionAllocator" do
     setup do
-      {:ok, prober} = RTPConnectionAllocator.start_link()
+      {:ok, prober} = RTPConnectionAllocator.create()
 
       RTPConnectionAllocator.update_bandwidth_estimation(prober, @initial_bandwidth_estimation)
 

--- a/test/support/webrtc/test_connection_allocator.ex
+++ b/test/support/webrtc/test_connection_allocator.ex
@@ -3,7 +3,10 @@ defmodule Membrane.RTC.Engine.Endpoint.WebRTC.TestConnectionAllocator do
   @behaviour Membrane.RTC.Engine.Endpoint.WebRTC.ConnectionAllocator
 
   @impl true
-  def start_link(), do: {:ok, self()}
+  def create(), do: {:ok, self()}
+
+  @impl true
+  def destroy(_pid), do: :ok
 
   @impl true
   def register_track_receiver(allocator, bandwidth, track, _options \\ []) do


### PR DESCRIPTION
RTPConnectionAllocator was linked to a parent process, but it wasn't manually terminated when WebRTC endpoint died, as links don't act if termination reason is `:normal`. This caused a severe and likely increasing resource leak.

To address this, `GenServer.stop/1` invokation was added in `handle_playing_to_prepared`, a symmetric callback to `handle_prepared_to_playing`, in which RtpConnectionAllocator is spawned.

# QA Strategy
I think manual QA is the way to go here, writing either a unit or an integration test for that is not trivial.
The best option I think is to use [observer](https://www.erlang.org/doc/apps/observer/observer_ug.html) to validate that RTPConnectionAllocator in fact dies.
I have already checked, but further verification is welcome

